### PR TITLE
Registration of Procs to handle access_token updates

### DIFF
--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -36,10 +36,13 @@ module Yt
 
       def authentication
         @authentication = current_authentication
-        @authentication ||= use_refresh_token! if @refresh_token
-        @authentication ||= use_authorization_code! if @authorization_code
-        @authentication ||= use_device_code! if @device_code
-        @authentication ||= raise_missing_authentication!
+
+        unless @authentication
+          @authentication = authenticate!
+          notify_authentication_handlers
+        end
+
+        @authentication
       end
 
       def authentication_url
@@ -58,6 +61,28 @@ module Yt
       end
 
     private
+
+      def notify_authentication_handlers
+        Yt.configuration.authentication_handlers.each do |handler|
+          begin
+            handler.call(self)
+          rescue => ex
+            # Catch and log all exceptions so associated handlers don't interfere with YT
+          end
+        end
+      end
+
+      def authenticate!
+        if @refresh_token
+          use_refresh_token!
+        elsif @authorization_code
+          use_authorization_code!
+        elsif @device_code
+          use_device_code!
+        else
+          raise_missing_authentication!
+        end
+      end
 
       def current_authentication
         @authentication ||= Yt::Authentication.new current_data if @access_token

--- a/lib/yt/models/configuration.rb
+++ b/lib/yt/models/configuration.rb
@@ -41,12 +41,16 @@ module Yt
       # @see https://console.developers.google.com Google Developers Console
       attr_accessor :api_key
 
+      # @return [Array<Proc>] Register a proc to handle token updates.
+      attr_accessor :authentication_handlers
+
       # Initialize the global configuration settings, using the values of
       # the specified following environment variables by default.
       def initialize
         @client_id = ENV['YT_CLIENT_ID']
         @client_secret = ENV['YT_CLIENT_SECRET']
         @api_key = ENV['YT_API_KEY']
+        @authentication_handlers = []
       end
     end
   end


### PR DESCRIPTION
Registration of handlers to be notified of authentication updates.

``` ruby
Yt.configure do |config|
  config.authentication_handlers << Proc.new {|account|  } #save account.access_token to your db
end
```

or via a ruby class that responds to `call`:

``` ruby
class AuthHandler
  def call(account)
    #save account.access_token to your database
  end
end

Yt.configure do |config|
  config.authentication_handlers << AuthHandler.new #save account.access_token to your db
end
```
