### PR TITLE
Add Asset Metadata, AssetSearch

### DIFF
--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -74,7 +74,6 @@ module Yt
         {data: data, auth: @auth}
       end
 
-
       def more_pages?
         @last_index.zero? || !@page_token.nil?
       end

--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -1,5 +1,6 @@
 require 'yt/collections/base'
 require 'yt/models/asset'
+require 'yt/models/asset_snippet'
 
 module Yt
   module Collections
@@ -15,6 +16,37 @@ module Yt
       end
 
     private
+
+      def new_item(data)
+        klass = (data["kind"] == "youtubePartner#assetSnippet") ? Yt::AssetSnippet : Yt::Asset
+        klass.new attributes_for_new_item(data)
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list assets
+      #   owned by the content owner.
+      # @see https://developers.google.com/youtube/partner/docs/v1/assets/list
+      def list_params
+        super.tap do |params|
+          params[:path] = assets_path
+          params[:params] = assets_params
+        end
+      end
+
+      def assets_params
+        apply_where_params! on_behalf_of_content_owner: @auth.owner_name
+      end
+
+      # @private
+      # @todo: This is one of three places outside of base.rb where @where_params
+      #   is accessed; it should be replaced with a filter on params instead.
+      def assets_path
+        @where_params ||= {}
+        if @where_params.empty? || @where_params.key?(:id)
+          '/youtube/partner/v1/assets'
+        else
+          '/youtube/partner/v1/assetSearch'
+        end
+      end
 
       # @return [Hash] the parameters to submit to YouTube to add a asset.
       # @see https://developers.google.com/youtube/partner/docs/v1/assets/insert

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -41,7 +41,7 @@ module Yt
       end
 
       # @private
-      # @todo: This is one of two places outside of base.rb where @where_params
+      # @todo: This is one of three places outside of base.rb where @where_params
       #   is accessed; it should be replaced with a filter on params instead.
       def claims_path
         @where_params ||= {}

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -71,7 +71,7 @@ module Yt
       # /videos should be used when the query specifies video IDs or a chart,
       # /search otherwise.
       # @return [Boolean] whether to use the /videos endpoint.
-      # @todo: This is one of two places outside of base.rb where @where_params
+      # @todo: This is one of three places outside of base.rb where @where_params
       #   is accessed; it should be replaced with a filter on params instead.
       def use_list_endpoint?
         @where_params ||= {}

--- a/lib/yt/models/asset.rb
+++ b/lib/yt/models/asset.rb
@@ -1,4 +1,5 @@
 require 'yt/models/base'
+require 'yt/models/asset_metadata'
 
 module Yt
   module Models
@@ -8,7 +9,7 @@ module Yt
       attr_reader :auth
 
       def initialize(options = {})
-        @data = options[:data]
+        @data = options.fetch(:data, {})
         @id = options[:id]
         @auth = options[:auth]
       end
@@ -24,6 +25,14 @@ module Yt
       has_one :ownership
       delegate :general_owners, :performance_owners, :synchronization_owners,
         :mechanical_owners, to: :ownership
+
+      def metadata_mine
+        @metadata_mine ||= Yt::Models::AssetMetadata.new data: @data.fetch('metadataMine', {})
+      end
+
+      def metadata_effective
+        @metadata_effective ||= Yt::Models::AssetMetadata.new data: @data.fetch('metadataEffective', {})
+      end
 
       # Soft-deletes the asset.
       # @note YouTube API does not provide a +delete+ method for the Asset
@@ -53,6 +62,12 @@ module Yt
       #   episode, general, movie, music_video, season, show, sound_recording,
       #   video_game, and web.
       has_attribute :type
+
+      # @return [Array<Yt::Models::Tag>] the list of asset labels associated
+      #   with the asset. You can apply a label to multiple assets to group
+      #   them. You can use the labels as search filters to perform bulk updates,
+      #   to download reports, or to filter YouTube Analytics.
+      has_attribute :label
 
 # Status
 

--- a/lib/yt/models/asset_metadata.rb
+++ b/lib/yt/models/asset_metadata.rb
@@ -1,0 +1,38 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # The AssetMetadata object specifies the metadata for an asset.
+    # @see https://developers.google.com/youtube/partner/docs/v1/assets#metadataMine
+    class AssetMetadata < Base
+      def initialize(options = {})
+        @data = options[:data]
+      end
+
+      # @return [String] A unique value that you, the metadata provider,
+      #   use to identify an asset. The value could be a unique ID that
+      #   you created for the asset or a standard identifier, such as an
+      #   ISRC.
+      def custom_id
+        @data['customId']
+      end
+
+      # @return [String] The asset's title or name.
+      def title
+        @data['title']
+      end
+
+      # @return [String] A description of the asset. The description may be
+      #   displayed on YouTube or in CMS. 
+      def notes
+        @data['notes']
+      end
+
+      # @return [String] the ID that YouTube assigns and uses to uniquely
+      #   identify the asset.
+      def description
+        @data['description']
+      end
+    end
+  end
+end

--- a/lib/yt/models/asset_snippet.rb
+++ b/lib/yt/models/asset_snippet.rb
@@ -1,0 +1,45 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube ContentID assetSnippets.
+    # @see https://developers.google.com/youtube/partner/docs/v1/assetSearch
+    class AssetSnippet < Base
+      attr_reader :auth
+
+      def initialize(options = {})
+        @data = options.fetch(:data, {})
+        @auth = options[:auth]
+      end
+
+      # @return [String] the ID that YouTube assigns and uses to uniquely
+      #   identify the asset.
+      has_attribute :id
+
+      # @return [String] the asset’s type. This value determines the metadata
+      #   fields that you can set for the asset. In addition, certain API
+      #   functions may only be supported for specific types of assets. For
+      #   example, composition assets may have more complex ownership data than
+      #   other types of assets.
+      #   Valid values for this property are: art_track_video, composition,
+      #   episode, general, movie, music_video, season, show, sound_recording,
+      #   video_game, and web.
+      has_attribute :type
+
+      # @return [String] the title of this asset.
+      has_attribute :title
+
+      # @return [String] the Custom ID assigned by the content owner to
+      #   this asset.
+      has_attribute :custom_id
+
+      # @return [String] the ISRC (International Standard Recording Code)
+      #   for this asset.
+      has_attribute :isrc
+
+      # @return [String] the ISWC (International Standard Musical Work Code)
+      #   for this asset.
+      has_attribute :iswc
+    end
+  end
+end


### PR DESCRIPTION
Usage:  Retrieve basic metadata around assets (title, notes, description, custom_id)
## Asset Metadata

``` ruby
content_owner = Yt::ContentOwner.new(...)
asset = content_owner.assets.where(id: 'A969176766549462', fetch_metadata: 'mine').first
asset.metadata_mine.title #=> "Master Final   Neu La Anh Fix"

asset = content_owner.assets.where(id: 'A969176766549462', fetch_metadata: 'effective').first
asset.metadata_effective.title #=> "Neu la anh" (different due to ownership conflicts)
```
## Asset Searching

``` ruby
content_owner.assets.where(labels: "campaign:cpiuwdz-8oc").size #=> 417
content_owner.assets.where(labels: "campaign:cpiuwdz-8oc").first.title #=> "Whoomp! (Supadupafly) (Xxl Hip House Mix)"
```
