### PR TITLE
Update collections/videos.rb default order

### DIFF
--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -55,7 +55,7 @@ module Yt
           params[:type] = :video
           params[:max_results] = 50
           params[:part] = 'snippet'
-          params[:order] = 'date'
+          params[:order] = 'relevance'
           params[:published_before] = @published_before if @published_before
           params.merge! @parent.videos_params if @parent
           apply_where_params! params


### PR DESCRIPTION
Previously, We were to ordering the search results for a query to be 'date' by default. (as in, order by most recently added videos). Change it to be order: 'relevance' instead. That is the what YouTube sorts by by default, and that is what most people expect to get when they do a search using the Yt gem. If they want newest they should explicitly ask for it.
