### PR TITLE
categoryId was being nullified through this function when updating videos

### DIFF
--- a/lib/yt/actions/base.rb
+++ b/lib/yt/actions/base.rb
@@ -24,6 +24,7 @@ module Yt
           when String then source.gsub('<', '‹').gsub('>', '›')
           when Array then source.map{|string| sanitize_brackets! string}
           when Hash then source.each{|k,v| source[k] = sanitize_brackets! v}
+          else source
         end
       end
     end


### PR DESCRIPTION
When passing an integer category_id during a video update, the method `#sanitize_brackets!` (called from resource.rb `#build_update_body`) was erasing the value and the video update would fail. This change returns the origin source when the value being sanitized isnt a string, array, or hash.
