### PR TITLE
Only require core_ext/hash from ActiveSupport

### DIFF
--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -57,7 +57,7 @@ module Yt
       end
 
       def rescue?(error)
-        'badRequest'.in?(error.reasons) && error.to_s =~ /did not conform/
+        error.reasons.include?('badRequest') && error.to_s =~ /did not conform/
       end
     end
   end

--- a/lib/yt/models/configuration.rb
+++ b/lib/yt/models/configuration.rb
@@ -57,13 +57,13 @@ module Yt
       # @return [Boolean] whether the logging output is extra-verbose.
       #   Useful when developing (e.g., to print the curl of every request).
       def developing?
-        log_level.to_s.in? %w(devel)
+        %w(devel).include? log_level.to_s
       end
 
       # @return [Boolean] whether the logging output is verbose.
       #   Useful when debugging (e.g., to print the curl of failing requests).
       def debugging?
-        log_level.to_s.in? %w(devel debug)
+        %w(devel debug).include? log_level.to_s
       end
     end
   end

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -1,8 +1,7 @@
 require 'net/http' # for Net::HTTP.start
 require 'uri' # for URI.json
 require 'json' # for JSON.parse
-require 'active_support' # does not load anything by default  but is required
-require 'active_support/core_ext' # for Hash.from_xml, Hash.to_param
+require 'active_support/core_ext/hash' # for Hash.from_xml, Hash.to_param
 
 require 'yt/errors/forbidden'
 require 'yt/errors/missing_auth'


### PR DESCRIPTION
This changes only two other files where `String#in?` was used. They now use `Array#include?`.
