### PR TITLE
New `by: :traffic_source` option for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ For more information about changelogs, check
 
 ## 0.14.0 - 2015-03-25
 
-* [FEATURE] New `:by` option for reports, to return results (e.g. `views`) either by day (default) or by traffic source.
+* [FEATURE] New `by: :traffic_source` option for reports, to return views (channels/videos) and estimated watched minutes (channels) by traffic source.
+* [FEATURE] New `by: :video` option for reports, to return views and estimated watched minutes (channels) by video.
 
 ## 0.13.12 - 2015-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.14.0 - 2015-03-25
+
+* [FEATURE] New `:by` option for reports, to return results (e.g. `views`) either by day (default) or by traffic source.
+
 ## 0.13.12 - 2015-03-23
 
 * [FEATURE] New channel/video reports: `favorites_added`, `favorites_removed`.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Use [Yt::Channel](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Chan
 * access the channels that the channel is subscribed to
 * subscribe to and unsubscribe from a channel
 * delete playlists from a channel
-* retrieve the daily earnings, views, comments, likes, dislikes, shares, subscribers gained/lost, estimated/average video watch and impressions of a channel
+* retrieve the daily earnings, views, comments, likes, dislikes, shares, subscribers gained/lost, estimated/average video watch and impressions of a channel by day
+* retrieve the views and estimated minutes watched by traffic source
 * retrieve the viewer percentage of a channel by gender and age group
 
 ```ruby
@@ -210,6 +211,9 @@ channel.average_view_duration #=>  {Sun, 22 Feb 2015=>329.0, Mon, 23 Feb 2015=>3
 channel.average_view_percentage # {Sun, 22 Feb 2015=>38.858253094977265, Mon, 23 Feb 2015=>37.40014235438217, …}
 channel.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 channel.viewer_percentage(gender: :male) #=> 49.12
+
+channel.views since: 7.days.ago, by: :traffic_source #=> {advertising: 10.0, related_video: 20.0, promoted: 5.0, subscriber: 1.0, channel: 3.0, other: 7.0}
+channel.estimated_minutes_watched since: 7.days.ago, by: :traffic_source #=> {annotation: 10.0, external_app: 20.0, external_url: 5.0, embedded: 1.0, search: 3.0}
 ```
 
 *The methods above require to be authenticated as the channel’s account (see below).*
@@ -232,6 +236,8 @@ channel.average_view_duration #=>  {Sun, 22 Feb 2015=>329.0, Mon, 23 Feb 2015=>3
 channel.average_view_percentage # {Sun, 22 Feb 2015=>38.858253094977265, Mon, 23 Feb 2015=>37.40014235438217, …}
 channel.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 channel.viewer_percentage(gender: :female) #=> 49.12
+channel.views since: 7.days.ago, by: :traffic_source #=> {advertising: 10.0, related_video: 20.0, promoted: 5.0, subscriber: 1.0, channel: 3.0, other: 7.0}
+channel.estimated_minutes_watched since: 7.days.ago, by: :traffic_source #=> {annotation: 10.0, external_app: 20.0, external_url: 5.0, embedded: 1.0, search: 3.0}
 
 channel.content_owner #=> 'CMSname'
 channel.linked_at #=> Wed, 28 May 2014
@@ -250,7 +256,8 @@ Use [Yt::Video](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Video)
 * access the annotations of a video
 * delete a video
 * like and dislike a video
-* retrieve the daily earnings, views, comments, likes, dislikes, shares, subscribers gained/lost, impressions and monetized playbacks of a video
+* retrieve the daily earnings, views, comments, likes, dislikes, shares, subscribers gained/lost, impressions and monetized playbacks of a video by day
+* retrieve the views of a video by traffic source
 * retrieve the viewer percentage of a video by gender and age group
 * retrieve data about live-streaming videos
 * retrieve the advertising options of a video
@@ -346,6 +353,8 @@ video.subscribers_lost from: '2014-08-30', to: '2014-08-31' #=> {Sat, 30 Aug 201
 video.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 video.viewer_percentage(gender: :female) #=> 49.12
 
+video.views since: 7.days.ago, by: :traffic_source #=> {advertising: 10.0, related_video: 20.0, promoted: 5.0, subscriber: 1.0, channel: 3.0, other: 7.0}
+
 video.delete #=> true
 ```
 
@@ -368,6 +377,8 @@ video.monetized_playbacks_on 5.days.ago #=> 123.0
 
 video.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 video.viewer_percentage(gender: :female) #=> 49.12
+
+video.views since: 7.days.ago, by: :traffic_source #=> {advertising: 10.0, related_video: 20.0, promoted: 5.0, subscriber: 1.0, channel: 3.0, other: 7.0}
 
 video.ad_formats #=> ["standard_instream", "trueview_instream"]
 ```

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -5,6 +5,7 @@ module Yt
     class Reports < Base
       DIMENSIONS = Hash.new({name: 'day', parse: -> (day) {Date.iso8601 day} }).tap do |hash|
         hash[:traffic_source] = {name: 'insightTrafficSourceType', parse: -> (type) {TRAFFIC_SOURCES.key type} }
+        hash[:video] = {name: 'video', parse: -> (video_id) { Yt::Video.new id: video_id, auth: @auth } }
       end
 
       # @see https://developers.google.com/youtube/analytics/v1/dimsmets/dims#Traffic_Source_Dimensions
@@ -62,6 +63,8 @@ module Yt
           params['end-date'] = @days_range.end
           params['metrics'] = @metric.to_s.camelize(:lower)
           params['dimensions'] = DIMENSIONS[@dimension][:name]
+          params['max-results'] = 10 if @dimension == :video
+          params['sort'] = "-#{@metric.to_s.camelize(:lower)}" if @dimension == :video
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.13.12'
+  VERSION = '0.14.0'
 end

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -111,6 +111,15 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'views can be grouped by video' do
+        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+
+        specify 'with the :by option set to :video' do
+          views = channel.views range.merge by: :video
+          expect(views.keys).to all(be_instance_of Yt::Video)
+        end
+      end
+
       describe 'comments can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:comments) { channel.comments_on 5.days.ago}
@@ -541,6 +550,15 @@ describe Yt::Channel, :partner do
         specify 'with the :by option set to :traffic_source' do
           estimated_minutes_watched = channel.estimated_minutes_watched range.merge by: :traffic_source
           expect(estimated_minutes_watched.keys - keys).to be_empty
+        end
+      end
+
+      describe 'estimated minutes watched can be grouped by video' do
+        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+
+        specify 'with the :by option set to :video' do
+          estimated_minutes_watched = channel.estimated_minutes_watched range.merge by: :video
+          expect(estimated_minutes_watched.keys).to all(be_instance_of Yt::Video)
         end
       end
 

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -86,6 +86,31 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'views can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          views = channel.views range
+          expect(views.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          views = channel.views range.merge by: :day
+          expect(views.keys).to eq range.values
+        end
+      end
+
+      describe 'views can be grouped by traffic source' do
+        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+        let(:keys) { Yt::Collections::Reports::TRAFFIC_SOURCES.keys }
+
+        specify 'with the :by option set to :traffic_source' do
+          views = channel.views range.merge by: :traffic_source
+          expect(views.keys - keys).to be_empty
+        end
+      end
+
       describe 'comments can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:comments) { channel.comments_on 5.days.ago}
@@ -115,6 +140,21 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.comments(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'comments can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          comments = channel.comments range
+          expect(comments.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          comments = channel.comments range.merge by: :day
+          expect(comments.keys).to eq range.values
         end
       end
 
@@ -150,6 +190,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'likes can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          likes = channel.likes range
+          expect(likes.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          likes = channel.likes range.merge by: :day
+          expect(likes.keys).to eq range.values
+        end
+      end
+
       describe 'dislikes can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:dislikes) { channel.dislikes_on 5.days.ago}
@@ -179,6 +234,21 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.dislikes(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'dislikes can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          dislikes = channel.dislikes range
+          expect(dislikes.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          dislikes = channel.dislikes range.merge by: :day
+          expect(dislikes.keys).to eq range.values
         end
       end
 
@@ -214,6 +284,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'shares can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          shares = channel.shares range
+          expect(shares.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          shares = channel.shares range.merge by: :day
+          expect(shares.keys).to eq range.values
+        end
+      end
+
       describe 'gained subscribers can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:subscribers_gained) { channel.subscribers_gained_on 5.days.ago}
@@ -243,6 +328,21 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.subscribers_gained(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'gained subscribers can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          subscribers_gained = channel.subscribers_gained range
+          expect(subscribers_gained.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          subscribers_gained = channel.subscribers_gained range.merge by: :day
+          expect(subscribers_gained.keys).to eq range.values
         end
       end
 
@@ -278,6 +378,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'lost subscribers can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          subscribers_lost = channel.subscribers_lost range
+          expect(subscribers_lost.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          subscribers_lost = channel.subscribers_lost range.merge by: :day
+          expect(subscribers_lost.keys).to eq range.values
+        end
+      end
+
       describe 'added favorites can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:favorites_added) { channel.favorites_added_on 5.days.ago}
@@ -307,6 +422,21 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.favorites_added(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'added favorites can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          favorites_added = channel.favorites_added range
+          expect(favorites_added.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          favorites_added = channel.favorites_added range.merge by: :day
+          expect(favorites_added.keys).to eq range.values
         end
       end
 
@@ -342,6 +472,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'removed favorites can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          favorites_removed = channel.favorites_removed range
+          expect(favorites_removed.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          favorites_removed = channel.favorites_removed range.merge by: :day
+          expect(favorites_removed.keys).to eq range.values
+        end
+      end
+
       describe 'estimated minutes watched can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:estimated_minutes_watched) { channel.estimated_minutes_watched_on 5.days.ago}
@@ -371,6 +516,31 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.estimated_minutes_watched(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'estimated minutes watched can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          estimated_minutes_watched = channel.estimated_minutes_watched range
+          expect(estimated_minutes_watched.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          estimated_minutes_watched = channel.estimated_minutes_watched range.merge by: :day
+          expect(estimated_minutes_watched.keys).to eq range.values
+        end
+      end
+
+      describe 'estimated minutes watched can be grouped by traffic source' do
+        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+        let(:keys) { Yt::Collections::Reports::TRAFFIC_SOURCES.keys }
+
+        specify 'with the :by option set to :traffic_source' do
+          estimated_minutes_watched = channel.estimated_minutes_watched range.merge by: :traffic_source
+          expect(estimated_minutes_watched.keys - keys).to be_empty
         end
       end
 
@@ -406,6 +576,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'average view duration can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          average_view_duration = channel.average_view_duration range
+          expect(average_view_duration.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          average_view_duration = channel.average_view_duration range.merge by: :day
+          expect(average_view_duration.keys).to eq range.values
+        end
+      end
+
       describe 'average view percentage can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:average_view_percentage) { channel.average_view_percentage_on 5.days.ago}
@@ -438,6 +623,21 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'average view percentage can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          average_view_percentage = channel.average_view_percentage range
+          expect(average_view_percentage.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          average_view_percentage = channel.average_view_percentage range.merge by: :day
+          expect(average_view_percentage.keys).to eq range.values
+        end
+      end
+
       describe 'impressions can be retrieved for a specific day' do
         context 'in which the channel was partnered' do
           let(:impressions) { channel.impressions_on 20.days.ago}
@@ -467,6 +667,21 @@ describe Yt::Channel, :partner do
 
         specify 'with a given end (:to option)' do
           expect(channel.impressions(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'impressions can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          impressions = channel.impressions range
+          expect(impressions.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          impressions = channel.impressions range.merge by: :day
+          expect(impressions.keys).to eq range.values
         end
       end
 

--- a/spec/requests/as_content_owner/video_spec.rb
+++ b/spec/requests/as_content_owner/video_spec.rb
@@ -77,6 +77,31 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'views can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          views = video.views range
+          expect(views.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          views = video.views range.merge by: :day
+          expect(views.keys).to eq range.values
+        end
+      end
+
+      describe 'views can be grouped by traffic source' do
+        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+        let(:keys) { Yt::Collections::Reports::TRAFFIC_SOURCES.keys }
+
+        specify 'with the :by option set to :traffic_source' do
+          views = video.views range.merge by: :traffic_source
+          expect(views.keys - keys).to be_empty
+        end
+      end
+
       describe 'comments can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:comments) { video.comments_on 5.days.ago}
@@ -106,6 +131,21 @@ describe Yt::Video, :partner do
 
         specify 'with a given end (:to option)' do
           expect(video.comments(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'comments can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          comments = video.comments range
+          expect(comments.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          comments = video.comments range.merge by: :day
+          expect(comments.keys).to eq range.values
         end
       end
 
@@ -141,6 +181,21 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'likes can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          likes = video.likes range
+          expect(likes.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          likes = video.likes range.merge by: :day
+          expect(likes.keys).to eq range.values
+        end
+      end
+
       describe 'dislikes can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:dislikes) { video.dislikes_on 5.days.ago}
@@ -170,6 +225,21 @@ describe Yt::Video, :partner do
 
         specify 'with a given end (:to option)' do
           expect(video.dislikes(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'dislikes can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          dislikes = video.dislikes range
+          expect(dislikes.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          dislikes = video.dislikes range.merge by: :day
+          expect(dislikes.keys).to eq range.values
         end
       end
 
@@ -205,6 +275,21 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'shares can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          shares = video.shares range
+          expect(shares.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          shares = video.shares range.merge by: :day
+          expect(shares.keys).to eq range.values
+        end
+      end
+
       describe 'gained subscribers can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:subscribers_gained) { video.subscribers_gained_on 5.days.ago}
@@ -234,6 +319,21 @@ describe Yt::Video, :partner do
 
         specify 'with a given end (:to option)' do
           expect(video.subscribers_gained(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'gained subscribers can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          subscribers_gained = video.subscribers_gained range
+          expect(subscribers_gained.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          subscribers_gained = video.subscribers_gained range.merge by: :day
+          expect(subscribers_gained.keys).to eq range.values
         end
       end
 
@@ -269,6 +369,21 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'lost subscribers can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          subscribers_lost = video.subscribers_lost range
+          expect(subscribers_lost.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          subscribers_lost = video.subscribers_lost range.merge by: :day
+          expect(subscribers_lost.keys).to eq range.values
+        end
+      end
+
       describe 'added favorites can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:favorites_added) { video.favorites_added_on 5.days.ago}
@@ -298,6 +413,21 @@ describe Yt::Video, :partner do
 
         specify 'with a given end (:to option)' do
           expect(video.favorites_added(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'added favorites can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          favorites_added = video.favorites_added range
+          expect(favorites_added.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          favorites_added = video.favorites_added range.merge by: :day
+          expect(favorites_added.keys).to eq range.values
         end
       end
 
@@ -333,6 +463,21 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'removed favorites can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          favorites_removed = video.favorites_removed range
+          expect(favorites_removed.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          favorites_removed = video.favorites_removed range.merge by: :day
+          expect(favorites_removed.keys).to eq range.values
+        end
+      end
+
       describe 'impressions can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:impressions) { video.impressions_on 20.days.ago}
@@ -365,6 +510,21 @@ describe Yt::Video, :partner do
         end
       end
 
+      describe 'impressions can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          impressions = video.impressions range
+          expect(impressions.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          impressions = video.impressions range.merge by: :day
+          expect(impressions.keys).to eq range.values
+        end
+      end
+
       describe 'monetized playbacks can be retrieved for a specific day' do
         context 'in which the video was partnered' do
           let(:monetized_playbacks) { video.monetized_playbacks_on 20.days.ago}
@@ -394,6 +554,21 @@ describe Yt::Video, :partner do
 
         specify 'with a given end (:to option)' do
           expect(video.monetized_playbacks(to: date).keys.max).to eq date.to_date
+        end
+      end
+
+      describe 'monetized_playbacks can be grouped by day' do
+        let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
+        let(:keys) { range.values }
+
+        specify 'without a :by option (default)' do
+          monetized_playbacks = video.monetized_playbacks range
+          expect(monetized_playbacks.keys).to eq range.values
+        end
+
+        specify 'with the :by option set to :day' do
+          monetized_playbacks = video.monetized_playbacks range.merge by: :day
+          expect(monetized_playbacks.keys).to eq range.values
         end
       end
 


### PR DESCRIPTION
Before this commit, reports were always returning day-by-day data
(e.g. views were returned as `{Thu => 10.0, Wed => 11.0, ...}`).

After this commit, two channel reports (`views`, `estimated_minutes_watched`)
and one video report (`views`) can also return data by traffic source.

For instance, you can now run:

``` ruby
channel.views since: 7.days.ago, by: :traffic_source
```

and it would return something like:

``` ruby
{advertising: 10.0, related_video: 20.0, promoted: 5.0, subscriber: 1.0, channel: 3.0, other: 7.0}
```
