### PR TITLE
added support for content owner upload to partnered channel

### DIFF
--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -10,7 +10,8 @@ module Yt
     class Assets < Base
       def insert(attributes = {})
         underscore_keys! attributes
-        body = {type: attributes[:type]}
+        # body = {type: attributes[:type]}
+        body = {metadataMine:{customId: attributes[:custom_id], title: attributes[:title]}, type: attributes[:type]}
         params = {on_behalf_of_content_owner: @auth.owner_name}
         do_insert(params: params, body: body)
       end

--- a/lib/yt/collections/resumable_sessions.rb
+++ b/lib/yt/collections/resumable_sessions.rb
@@ -15,7 +15,7 @@ module Yt
       # URL to upload the object file (and eventually resume the upload).
       # @param [Integer] content_length the size (bytes) of the object to upload.
       # @param [Hash] options the metadata to add to the uploaded object.
-      def insert(content_length, body = {})
+      def insert(content_length, body = {}, content_owner_params = {})
         @headers = headers_for content_length
         do_insert body: body, headers: @headers
       end
@@ -29,8 +29,14 @@ module Yt
       def insert_params
         super.tap do |params|
           params[:response_format] = nil
-          params[:path] = @parent.upload_path
-          params[:params] = @parent.upload_params.merge uploadType: 'resumable'
+          params[:path] = @parent.upload_path 
+          content_owner_params = @parent.instance_variable_get( '@content_owner_params' )        
+          unless content_owner_params.nil?
+            all_params = content_owner_params.merge uploadType: 'resumable'
+            params[:params] = @parent.upload_params.merge all_params
+          else
+            params[:params] = @parent.upload_params.merge uploadType: 'resumable'
+          end
         end
       end
 

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -55,12 +55,13 @@ module Yt
       # @option params [Array<String>] :title The video’s tags.
       # @option params [String] :privacy_status The video’s privacy status.
       # @return [Yt::Models::Video] the newly uploaded video.
-      def upload_video(path_or_url, params = {})
+      def upload_video(path_or_url, params = {}, content_owner_details = {})
         file = open path_or_url, 'rb'
-        session = resumable_sessions.insert file.size, upload_body(params)
+        session = resumable_sessions.insert file.size, upload_body(params), upload_content_owner(content_owner_details)
 
         session.update(body: file) do |data|
           Yt::Video.new id: data['id'], snippet: data['snippet'], status: data['privacyStatus'], auth: self
+          
         end
       end
 
@@ -85,6 +86,21 @@ module Yt
       # associated to the uploaded file.
       def upload_params
         {part: 'snippet,status'}
+      end
+
+      # @private
+      # Tells `has_many :resumable_sessions` what content owner data to set in the object
+      # associated to the uploaded file.
+      def upload_content_owner(content_owner_details = {})
+        {}.tap do |content_owner_params|
+          owner = content_owner_details[:content_owner]
+          content_owner_params[:onBehalfOfContentOwner] = owner if owner
+
+          channel = content_owner_details[:channel]
+          content_owner_params[:onBehalfOfContentOwnerChannel] = channel if channel
+          @content_owner_params = content_owner_params
+        end
+        @content_owner_params
       end
 
       # @private


### PR DESCRIPTION
Here is the script that I'm using to call the updated account.upload_video method:

  video_params = {
    title: 'My new video',
    privacy_status: 'private',
    category_id: 17,
    description: 'This is the description of my new video',
    tags: ['music']
  }

  content_owner_params = {
    content_owner: CMSname,
    channel: ChannelId
  }

  yt_video = video_upload(account, video_url, video_params, content_owner_params)

  # -- Yt GEM Video UPLOAD -- 
  def self.video_upload(account, video_url, video_params = {}, content_owner_params = {})
    yt_video = account.upload_video( video_url,
             video_params, content_owner_params
            )
  rescue Yt::Error => @video_error
    puts "Video Upload Error (YTError) " + @video_error.message
  end
