### PR TITLE
Fix: only rescue SSLErrorWaitReadable if defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.14.6 - 2015-04-17
+
+* [BUGFIX] Rescue OpenSSL::SSL::SSLErrorWaitReadable only on version of Ruby that define it.
+
 ## 0.14.5 - 2015-04-15
 
 * [BUGFIX] Raise `Yt::Errors::RequestError` when passing an invalid path or URL to `upload_thumbnail`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.14.5'
+    gem 'yt', '~> 0.14.6'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -206,7 +206,18 @@ module Yt
         Errno::ENETUNREACH,
         Errno::ECONNRESET,
         Net::HTTPServerError
-      ] + (RUBY_VERSION < '2' ? [] : [OpenSSL::SSL::SSLErrorWaitReadable])
+      ] + extra_server_errors
+    end
+
+    # Returns the list of server errors that are only raised (and therefore
+    # can only be rescued) by specific versions of Ruby.
+    # @see: https://github.com/Fullscreen/yt/pull/110
+    def extra_server_errors
+      if defined? OpenSSL::SSL::SSLErrorWaitReadable
+        [OpenSSL::SSL::SSLErrorWaitReadable]
+      else
+        []
+      end
     end
 
     # Sleeps for a while and returns true for the first +max_retries+ times,

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.14.5'
+  VERSION = '0.14.6'
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -120,7 +120,7 @@ describe Yt::Request do
       # NOTE: This test is just a reflection of YouTube irrational behavior of
       # being unavailable once in a while, and therefore causing Net::HTTP to
       # fail, although retrying after some seconds works.
-      context 'an OpenSSL::SSL::SSLErrorWaitReadable', ruby2: true do
+      context 'an OpenSSL::SSL::SSLErrorWaitReadable', ruby21: true do
         let(:http_error) { OpenSSL::SSL::SSLErrorWaitReadable.new }
 
         context 'every time' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,6 @@ RSpec.configure do |config|
   # @note: Some tests might take too long to run on Ruby 1.9.3 which does not
   #   support "size" for Enumerator, so we are better off skipping them.
   config.filter_run_excluding ruby2: true if RUBY_VERSION < '2'
+  # @note: See https://github.com/Fullscreen/yt/issues/103
+  config.filter_run_excluding ruby21: true if RUBY_VERSION < '2.1'
 end


### PR DESCRIPTION
See https://github.com/Fullscreen/yt/issues/103 for the full discussion.

Closes #103
