### PR TITLE
pass through attributes to asset insertion

### DIFF
--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -9,10 +9,8 @@ module Yt
     # Resources with assets are: {Yt::Models::ContentOwner content owners}.
     class Assets < Base
       def insert(attributes = {})
-        underscore_keys! attributes
-        body = {type: attributes[:type]}
         params = {on_behalf_of_content_owner: @auth.owner_name}
-        do_insert(params: params, body: body)
+        do_insert(params: params, body: attributes)
       end
 
     private

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -241,7 +241,7 @@ describe Yt::ContentOwner, :partner do
   #   Therefore, the test is commented out, otherwise a new asset would
   #   be created every time the test is run.
   # describe 'assets can be added' do
-  #   let(:params) { {type: 'web'} }
+  #   let(:params) { {type: 'web', metadata_mine: {title: "Test Asset Title"}} }
   #   before { @asset = $content_owner.create_asset params }
   #   after { @asset.delete } # This does not seem to work
   #   it { expect(@asset).to be_a Yt::Asset }


### PR DESCRIPTION
Closes #147 

Pass through attributes to asset insertion.

Commented out spec works.
