### PR TITLE
fix response parsing

### DIFF
--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -183,7 +183,7 @@ module Yt
     def parse_response!
       response.body = case @response_format
         when :xml then Hash.from_xml response.body
-        when :json then JSON response.body
+        when :json then JSON response.body, {}
       end if response.body
     end
 


### PR DESCRIPTION
with `json -> 1.8.2` any request is failing with error `ArgumentError: options must be a hash.
from /home/maxim/.rvm/gems/ruby-2.2.0@mytv/gems/json-1.8.2/lib/json/common.rb:468:in`parse'`
