### PR TITLE
Accept `:includes` in reports by video or playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.23.2 - 2015-05-20
+
+* [FEATURE] Accept `:includes` in reports by video, related video and playlist to preload parts.
+
 ## 0.23.1 - 2015-05-19
 
 * [FEATURE] New `by: :month` option for reports.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.23.1'
+    gem 'yt', '~> 0.23.2'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/playlists.rb
+++ b/lib/yt/collections/playlists.rb
@@ -13,7 +13,9 @@ module Yt
       end
 
       def playlists_params
-        resources_params.merge channel_id: @parent.id
+        params = resources_params
+        params.merge! channel_id: @parent.id if @parent
+        apply_where_params! params
       end
 
       def insert_parts

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -10,10 +10,10 @@ module Yt
         hash[:traffic_source] = {name: 'insightTrafficSourceType', parse: ->(source, *values) { @metrics.keys.zip(values.map{|v| {TRAFFIC_SOURCES.key(source) => v}}).to_h} }
         hash[:playback_location] = {name: 'insightPlaybackLocationType', parse: ->(location, *values) { @metrics.keys.zip(values.map{|v| {PLAYBACK_LOCATIONS.key(location) => v}}).to_h} }
         hash[:embedded_player_location] = {name: 'insightPlaybackLocationDetail', parse: ->(url, *values) {@metrics.keys.zip(values.map{|v| {url => v}}).to_h} }
-        hash[:related_video] = {name: 'insightTrafficSourceDetail', parse: ->(video_id, *values) { @metrics.keys.zip(values.map{|v| {Yt::Video.new(id: video_id, auth: @auth) => v}}).to_h} }
+        hash[:related_video] = {name: 'insightTrafficSourceDetail', parse: ->(video_id, *values) { @metrics.keys.zip(values.map{|v| {video_id => v}}).to_h} }
         hash[:search_term] = {name: 'insightTrafficSourceDetail', parse: ->(search_term, *values) {@metrics.keys.zip(values.map{|v| {search_term => v}}).to_h} }
-        hash[:video] = {name: 'video', parse: ->(video_id, *values) { @metrics.keys.zip(values.map{|v| {Yt::Video.new(id: video_id, auth: @auth) => v}}).to_h} }
-        hash[:playlist] = {name: 'playlist', parse: ->(playlist_id, *values) { @metrics.keys.zip(values.map{|v| {Yt::Playlist.new(id: playlist_id, auth: @auth) => v}}).to_h} }
+        hash[:video] = {name: 'video', parse: ->(video_id, *values) { @metrics.keys.zip(values.map{|v| {video_id => v}}).to_h} }
+        hash[:playlist] = {name: 'playlist', parse: ->(playlist_id, *values) { @metrics.keys.zip(values.map{|v| {playlist_id => v}}).to_h} }
         hash[:device_type] = {name: 'deviceType', parse: ->(type, *values) {@metrics.keys.zip(values.map{|v| {type.downcase.to_sym => v}}).to_h} }
         hash[:country] = {name: 'country', parse: ->(country_code, *values) { @metrics.keys.zip(values.map{|v| {country_code => v}}).to_h} }
         hash[:state] = {name: 'province', parse: ->(country_and_state_code, *values) { @metrics.keys.zip(values.map{|v| {country_and_state_code[3..-1] => v}}).to_h} }

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.23.1'
+  VERSION = '0.23.2'
 end

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -330,6 +330,12 @@ describe Yt::Channel, :partner do
           views = channel.views range.merge by: :related_video
           expect(views.keys).to all(be_instance_of Yt::Video)
         end
+
+        specify 'and provided with an :includes option to preload parts' do
+          views = channel.views range.merge by: :related_video, includes: [:statistics]
+          expect(views.keys.map{|v| v.instance_variable_defined? :@status}).to all(be false)
+          expect(views.keys.map{|v| v.instance_variable_defined? :@statistics_set}).to all(be true)
+        end
       end
 
       describe 'views can be grouped by search term' do
@@ -348,6 +354,12 @@ describe Yt::Channel, :partner do
           views = channel.views range.merge by: :video
           expect(views.keys).to all(be_instance_of Yt::Video)
         end
+
+        specify 'and provided with an :includes option to preload parts' do
+          views = channel.views range.merge by: :video, includes: [:statistics]
+          expect(views.keys.map{|v| v.instance_variable_defined? :@status}).to all(be false)
+          expect(views.keys.map{|v| v.instance_variable_defined? :@statistics_set}).to all(be true)
+        end
       end
 
       describe 'views can be grouped by playlist' do
@@ -356,6 +368,12 @@ describe Yt::Channel, :partner do
         specify 'with the :by option set to :playlist' do
           views = channel.views range.merge by: :playlist
           expect(views.keys).to all(be_instance_of Yt::Playlist)
+        end
+
+        specify 'and provided with an :includes option to preload parts' do
+          views = channel.views range.merge by: :playlist, includes: [:status]
+          expect(views.keys.map{|playlist| playlist.instance_variable_defined? :@content_details}).to all(be false)
+          expect(views.keys.map{|playlist| playlist.instance_variable_defined? :@status}).to all(be true)
         end
       end
 


### PR DESCRIPTION
This reduces the number of HTTP calls; for instance if you want to
know the top videos of a channel and want to print out the title,
duration and view count for each video, you can write:

```
parts = %i(snippet statistics content_details)
views = yt_channel.views from: from, to: to, by: :video, includes: parts
```

which will retrieve _in one HTTP call_ all the parts for all the videos.

Also bump version to 0.23.2
