### PR TITLE
Don't raise error when YT returns deleted videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.24.1 - 2015-07-01
+
+* [BUGFIX] Don't raise error when YouTube returns a deleted video while eager loading
+
 ## 0.24.0 - 2015-05-21
 
 **How to upgrade**

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.24.0'
+    gem 'yt', '~> 0.24.1'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -48,7 +48,7 @@ module Yt
                 when 'statistics' then video.statistics_set.data
                 when 'contentDetails' then video.content_detail.data
               end
-            end
+            end if video
           end
 
           if include_category

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.24.0'
+  VERSION = '0.24.1'
 end

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -581,7 +581,7 @@ describe Yt::Channel, :partner do
       describe 'dislikes can be retrieved for a single country' do
         let(:country_code) { 'US' }
         let(:dislikes) { channel.dislikes since: date, by: by, in: location }
-        let(:date) { 4.days.ago }
+        let(:date) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
 
         context 'and grouped by day' do
           let(:by) { :day }
@@ -1405,7 +1405,7 @@ describe Yt::Channel, :partner do
       describe 'annotation clicks can be retrieved for a single country' do
         let(:country_code) { 'US' }
         let(:annotation_clicks) { channel.annotation_clicks since: date, by: by, in: location }
-        let(:date) { 4.days.ago }
+        let(:date) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
 
         context 'and grouped by day' do
           let(:by) { :day }
@@ -1504,7 +1504,7 @@ describe Yt::Channel, :partner do
       describe 'annotation click-through rate can be retrieved for a single country' do
         let(:country_code) { 'US' }
         let(:annotation_click_through_rate) { channel.annotation_click_through_rate since: date, by: by, in: location }
-        let(:date) { 4.days.ago }
+        let(:date) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
 
         context 'and grouped by day' do
           let(:by) { :day }
@@ -1579,7 +1579,7 @@ describe Yt::Channel, :partner do
       end
 
       describe 'annotation click-through rate can be grouped by country' do
-        let(:range) { {since: 4.days.ago, until: 3.days.ago} }
+        let(:range) { {since: ENV['YT_TEST_PARTNER_VIDEO_DATE']} }
 
         specify 'with the :by option set to :country' do
           rate = channel.annotation_click_through_rate range.merge by: :country

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -22,7 +22,7 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   specify 'with a chart parameter, only returns videos of that chart', :ruby2 do
-    expect(videos.where(chart: 'mostPopular').size).to be 200
+    expect(videos.where(chart: 'mostPopular').size).to be 30
   end
 
   context 'with a list of parts' do


### PR DESCRIPTION
If you list the videos of a channel, sometimes YouTube includes the deleted videos. 
Then, when you try to eager load the other parts, YouTube says the video does not exist and raises an error.

In these cases, simply don't eager load.
See https://github.com/Fullscreen/channelplus/issues/87
