### PR TITLE
Fix: don't override publishedBefore with user data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.24.9 - 2015-06-19
+
+* [BUGFIX] Let more than `max_results` videos be retrieved even when a `published_before` where condition is specified.
+
 ## 0.24.8 - 2015-06-18
 
 * [FEATURE] New `by: :week` option for reports.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.24.8'
+    gem 'yt', '~> 0.24.9'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -97,9 +97,10 @@ module Yt
           params[:max_results] = 50
           params[:part] = 'snippet'
           params[:order] = 'date'
-          params[:published_before] = @published_before if @published_before
           params.merge! @parent.videos_params if @parent
           apply_where_params! params
+          params[:published_before] = @published_before if @published_before
+          params
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.24.8'
+  VERSION = '0.24.9'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -88,6 +88,14 @@ describe Yt::Channel, :device_app do
           expect(channel.videos.count).to be > 500
           expect(channel.videos.where(order: 'viewCount').count).to be 500
         end
+
+        specify 'over 500 videos can be retrieved even with a publishedBefore condition' do
+          # @note: these tests are slow because they go through multiple pages
+          # of results to test that we can overcome YouTube’s limitation of only
+          # returning the first 500 results when ordered by date.
+          today = Date.today.beginning_of_day.iso8601(0)
+          expect(channel.videos.where(published_before: today).count).to be > 500
+        end
       end
     end
 


### PR DESCRIPTION
This fixes a very specific use case. If you are trying to retrieve
a list of videos by date, and let Yt retrieve all the videos by
means of specifying a different `publishedBefore` for each interval,
then any `.where(published_before: ...)` condition specified by the
user should be disregarded after the first interval.
