### PR TITLE
Temporarily return less playlists in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.24.10 - 2015-06-25
+
+* [BUGFIX] Don't break reports `by: :playlist` when trying to fetch their part by limiting to result to 50 playlists.
+
 ## 0.24.9 - 2015-06-19
 
 * [BUGFIX] Let more than `max_results` videos be retrieved even when a `published_before` where condition is specified.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.24.9'
+    gem 'yt', '~> 0.24.10'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -129,7 +129,7 @@ module Yt
           params['metrics'] = @metrics.keys.join(',').to_s.camelize(:lower)
           params['dimensions'] = DIMENSIONS[@dimension][:name] unless @dimension == :range
           params['max-results'] = 10 if @dimension == :video
-          params['max-results'] = 200 if @dimension == :playlist
+          params['max-results'] = 50 if @dimension == :playlist
           params['max-results'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
           params['sort'] = "-#{@metrics.keys.join(',').to_s.camelize(:lower)}" if @dimension.in? [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer]
           params[:filters] = "video==#{@videos.join ','}" if @videos

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.24.9'
+  VERSION = '0.24.10'
 end


### PR DESCRIPTION
Although YouTube Analytics is able to provide 200 playlists at the
time for reports (e.g., views per playlist), returning more than 50
might break the related requests that Yt makes to obtain parts of
each playlist (id, snippet).

This is similar to 02c9405c and could be fixed by keeping the limit
to 200 and by modifying http://git.io/vt38K#L284L294 to fetch the
parts of the playlists in batches of 50.

This commit _partially_ solves the problem by limiting the result to
50 playlists instead.
