### PR TITLE
Add ability to create Yt::Video from an embed url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.1 - Unreleased
+
+* [ENHANCEMENT] `Yt::Video.new` accepts embedded video url.
+
 ## 0.25.0 - 2015-06-29
 
 **How to upgrade**

--- a/lib/yt/models/url.rb
+++ b/lib/yt/models/url.rb
@@ -71,6 +71,7 @@ module Yt
         %W{
           youtube\\.com/watch\\?v=#{video_id}
           youtu\\.be/#{video_id}
+          youtube\\.com/embed/#{video_id}
         }
       end
 

--- a/spec/models/url_spec.rb
+++ b/spec/models/url_spec.rb
@@ -19,6 +19,12 @@ describe Yt::URL do
     it {expect(url.id).to eq 'MESycYJytkU' }
   end
 
+  context 'given an embed video URL' do
+    let(:text) { 'https://www.youtube.com/embed/MESycYJytkU' }
+    it {expect(url.kind).to eq :video }
+    it {expect(url.id).to eq 'MESycYJytkU' }
+  end
+
   context 'given a playlist-embedded video URL' do
     let(:text) { 'youtube.com/watch?v=MESycYJytkU&list=LLxO1tY8h1AhOz0T4ENwmpow' }
     it {expect(url.kind).to eq :video }


### PR DESCRIPTION
Reference issue [#210](https://github.com/Fullscreen/yt/issues/210)
