### PR TITLE
Add .includes(:video) to .playlist_items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.2 - 2015-07-22
+
+* [FEATURE] Add .includes(:video) to .playlist_items to eager-load video data of a list of playlist items.
+
 ## 0.25.1 - 2015-07-06
 
 * [ENHANCEMENT] `Yt::Video.new` accepts embedded video url.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.25.1'
+    gem 'yt', '~> 0.25.2'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/playlist_item.rb
+++ b/lib/yt/models/playlist_item.rb
@@ -88,6 +88,13 @@ module Yt
         !@id.nil?
       end
 
+      # @private
+      # Override Resource's new to set video if the response includes it
+      def initialize(options = {})
+        super options
+        @video = options[:video] if options[:video]
+      end
+
     private
 
       def resource_id

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.1'
+  VERSION = '0.25.2'
 end

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -20,9 +20,31 @@ describe Yt::Playlist, :device_app do
       expect(playlist.privacy_status).to be_a String
     end
 
-    it { expect(playlist.playlist_items.first).to be_a Yt::PlaylistItem }
-    it { expect(playlist.playlist_items.first.snippet).to be_complete }
-    it { expect(playlist.playlist_items.first.position).not_to be_nil }
+    describe '.playlist_items' do
+      let(:item) { playlist.playlist_items.first }
+
+      specify 'returns the playlist item with the complete snippet' do
+        expect(item).to be_a Yt::PlaylistItem
+        expect(item.snippet).to be_complete
+        expect(item.position).not_to be_nil
+      end
+
+      specify 'does not eager-load the attributes of the item’s video' do
+        expect(item.video.instance_variable_defined? :@snippet).to be false
+        expect(item.video.instance_variable_defined? :@status).to be false
+        expect(item.video.instance_variable_defined? :@statistics_set).to be false
+      end
+    end
+
+    describe '.playlist_items.includes(:video)' do
+      let(:item) { playlist.playlist_items.includes(:video).first }
+
+      specify 'eager-loads the snippet, status and statistics of each video' do
+        expect(item.video.instance_variable_defined? :@snippet).to be true
+        expect(item.video.instance_variable_defined? :@status).to be true
+        expect(item.video.instance_variable_defined? :@statistics_set).to be true
+      end
+    end
   end
 
   context 'given an unknown playlist' do


### PR DESCRIPTION
Closes #213

Note that there is currently no way to specify _which_ parts of the video
to eager-load: they are hard-coded to snippet, statistics, status.

These are the most common parts, and therefore the ones loaded with the
short syntax `playlist.playlist_items.includes(:video)`.

In the future, we might have `includes` accept a hash (rather than a symbol)
to specify the parts, such as `playlist.playlist_items.includes(video: :status)`.
