### PR TITLE
Add `related_playlist` to Account and Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.4 - 2015-07-27
+
+* [FEATURE] Add `channel.related_playlist` and `account.related_playlists` to access "Liked Videos", "Uploads", etc.
+
 ## 0.25.3 - 2015-07-23
 
 * [BUGFIX] Don’t run an infinite loop when calling `.playlist_items.includes(:video)` on a playlist with only private or deleted videos

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.25.3'
+    gem 'yt', '~> 0.25.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/YOUTUBE_IT.md
+++ b/YOUTUBE_IT.md
@@ -180,37 +180,18 @@ channel = Yt::Channel.new url: 'youtube.com/liz'
 channel.videos.where(q: 'penguin')
 ```
 
-<!--
-
-TODO: Although FAVORITE is somehow deprecated, it can still be retrieved with
-V3. First, get the contentDetails of the account's channel and you'll get
-
-{"relatedPlaylists"=>
-  {"likes"=>"LLrWYT-_Xncr1BLPfPNr50sQ",
-   "favorites"=>"FLrWYT-_Xncr1BLPfPNr50sQ",
-   "uploads"=>"UUrWYT-_Xncr1BLPfPNr50sQ",
-   "watchHistory"=>"HLrWYT-_Xncr1BLPfPNr50sQ",
-   "watchLater"=>"WLrWYT-_Xncr1BLPfPNr50sQ"},
-
-Then you can list the videos of the "favorites" playlist. That playlist does
-not exist for new YouTube account, but you can still add a video to it, and
-it will magically appear (and also, DELETE PLAYLIST will be disabled)
-
 List videos favorited by user:
 
 ```ruby
 # with youtube_it
 client = YouTubeIt::Client.new
 client.videos_by(:favorites, :user => 'liz')
-# with yt: not supported (was removed from YouTube API V3)
-
-or maybe add .liked_videos and .disliked_videos here !!!!!
-
+# with yt: note that only *old* channels have a "Favorites" playlist, since
+# "Favorites" has been deprecated by YouTube in favor of "Liked Videos".
+channel = Yt::Channel.new url: 'youtube.com/liz'
+channel.related_playlists.find{|p| p.title == 'Favorites'}
 ```
 
-
-
--->
 
 Retrieve video by ID:
 
@@ -509,32 +490,16 @@ client.delete_comment(video_id, comment_id)
 # with yt: not supported (was removed from YouTube API V3)
 ```
 
-<!--
 List Favorites:
-
-
-TODO: Although FAVORITE is somehow deprecated, it can still be retrieved with
-V3. First, get the contentDetails of the account's channel and you'll get
-
-{"relatedPlaylists"=>
-  {"likes"=>"LLrWYT-_Xncr1BLPfPNr50sQ",
-   "favorites"=>"FLrWYT-_Xncr1BLPfPNr50sQ",
-   "uploads"=>"UUrWYT-_Xncr1BLPfPNr50sQ",
-   "watchHistory"=>"HLrWYT-_Xncr1BLPfPNr50sQ",
-   "watchLater"=>"WLrWYT-_Xncr1BLPfPNr50sQ"},
-
-Then you can list the videos of the "favorites" playlist. That playlist does
-not exist for new YouTube account, but you can still add a video to it, and
-it will magically appear (and also, DELETE PLAYLIST will be disabled)
-
 
 ```ruby
 # with youtube_it
 client = # new client initialized with either OAuth or AuthSub
 client.favorites(user) # default: current user
-# with yt
-
-# TODO: ADD account.liked_videos and .disliked_videos
+# with yt: note that only *old* channels have a "Favorites" playlist, since
+# "Favorites" has been deprecated by YouTube in favor of "Liked Videos".
+account = Yt::Account.new access_token: 'access_token'
+account.related_playlists.find{|p| p.title == 'Favorites'}
 ```
 
 Add Favorite:
@@ -723,36 +688,39 @@ playlist_item = Yt::PlaylistItem.new id: playlist_entry_id, auth: account
 playlist_item.update position: position
 ```
 
-<!--
-
-
-TODO: Although WATCHLATER is somehow deprecated, it can still be retrieved with
-V3. First, get the contentDetails of the account's channel and you'll get
-
-{"relatedPlaylists"=>
-  {"likes"=>"LLrWYT-_Xncr1BLPfPNr50sQ",
-   "favorites"=>"FLrWYT-_Xncr1BLPfPNr50sQ",
-   "uploads"=>"UUrWYT-_Xncr1BLPfPNr50sQ",
-   "watchHistory"=>"HLrWYT-_Xncr1BLPfPNr50sQ",
-   "watchLater"=>"WLrWYT-_Xncr1BLPfPNr50sQ"},
-
-Then you can list the videos of the "watch later" playlist. That playlist does
-not exist for new YouTube account, but you can still add a video to it, and
-it will magically appear (and also, DELETE PLAYLIST will be disabled)
-
-
 Select All Videos From your Watch Later Playlist:
-  $ watcher_later = client.watcherlater(user) #default: current user
-  $ watcher_later.videos
+
+```ruby
+# with youtube_it
+watcher_later = client.watcherlater(user) #default: current user
+watcher_later.videos
+# with yt
+account = Yt::Account.new access_token: 'access_token'
+watch_later = account.related_playlists.find{|p| p.title == 'Watch Later'}
+watch_later.playlist_items.map{|item| item.video}
+```
 
 Add Video To Watcher Later Playlist:
-  $ client.add_video_to_watchlater(video_id)
+
+```ruby
+# with youtube_it
+client.add_video_to_watchlater(video_id)
+# with yt
+account = Yt::Account.new access_token: 'access_token'
+watch_later = account.related_playlists.find{|p| p.title == 'Watch Later'}
+watch_later.add_video video_id
+```
 
 Remove Video From Watch Later Playlist:
-  $ client.delete_video_from_watchlater(watchlater_entry_id)
 
--->
-
+```ruby
+# with youtube_it
+client.delete_video_from_watchlater(watchlater_entry_id)
+# with yt
+account = Yt::Account.new access_token: 'access_token'
+watch_later = account.related_playlists.find{|p| p.title == 'Watch Later'}
+watch_later.delete_playlist_items video_id: video_id
+```
 
 <!-- TODO: Add using https://developers.google.com/youtube/v3/docs/search/list#relatedToVideoId
 

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -7,7 +7,7 @@ module Yt
   module Actions
     module List
       delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first,
-        :flat_map, :map, :size, to: :list
+        :flat_map, :map, :select, :size, to: :list
 
       def first!
         first.tap{|item| raise Errors::NoItems, error_message unless item}
@@ -41,7 +41,7 @@ module Yt
       def total_results
         response = list_request(list_params).run
         total_results = response.body.fetch('pageInfo', {})['totalResults']
-        total_results ||= response.body.fetch(items_key, []).size
+        total_results ||= extract_items(response.body).size
       end
 
       def find_next
@@ -93,7 +93,7 @@ module Yt
       def fetch_page(params = {})
         @last_response = list_request(params).run
         token = @last_response.body['nextPageToken']
-        items = @last_response.body.fetch items_key, []
+        items = extract_items @last_response.body
         {items: items, token: token}
       end
 
@@ -121,6 +121,10 @@ module Yt
           params[:exptected_response] = Net::HTTPOK
           params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key
         end
+      end
+
+      def extract_items(list)
+        list.fetch items_key, []
       end
 
       def items_key

--- a/lib/yt/collections/related_playlists.rb
+++ b/lib/yt/collections/related_playlists.rb
@@ -1,0 +1,43 @@
+require 'yt/collections/playlists'
+
+module Yt
+  module Collections
+    class RelatedPlaylists < Playlists
+
+    private
+
+      # Retrieving related playlists requires to hit the /channels endpoint.
+      def list_resources
+        'channels'
+      end
+
+      # The related playlists are included in the content details of a channel.
+      def playlists_params
+        {part: 'contentDetails', id: @parent.id}
+      end
+
+      # The object to create is "Yt::Models::Playlist", not "RelatedPlaylist"
+      def resource_class
+        Yt::Models::Playlist
+      end
+
+      # The related playlists are nested inside the "relatedPlaylists" key.
+      def extract_items(list)
+        if (items = super).any?
+          items.first['contentDetails'].fetch 'relatedPlaylists', {}
+        end
+      end
+
+      # Since there are at most 5 related playlists, they can be eager-loaded.
+      def eager_load_items_from(items)
+        conditions = {id: items.values.join(','), part: 'snippet,status'}
+        Collections::Playlists.new(auth: @auth).where conditions
+      end
+
+      # Related playlists are eager-loaded, there’s no need to load them again.
+      def new_item(playlist)
+        playlist
+      end
+    end
+  end
+end

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -134,6 +134,12 @@ module Yt
       #   @return [Yt::Collections::Playlists] the playlists owned by the account.
       delegate :playlists, to: :channel
 
+      # @!attribute [r] related_playlists
+      #   @return [Yt::Collections::Playlists] the playlists associated with the
+      #     account, such as the playlist of uploaded or liked videos.
+      #   @see https://developers.google.com/youtube/v3/docs/channels#contentDetails.relatedPlaylists
+      delegate :related_playlists, to: :channel
+
       # @!attribute [r] subscribed_channels
       #   @return [Yt::Collections::SubscribedChannels] the channels that the
       #     account is subscribed to.

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -94,6 +94,12 @@ module Yt
       #   @return [Yt::Collections::Playlists] the channel’s playlists.
       has_many :playlists
 
+      # @!attribute [r] related_playlists
+      #   @return [Yt::Collections::Playlists] the playlists associated with the
+      #     channel, such as the playlist of uploaded or liked videos.
+      #   @see https://developers.google.com/youtube/v3/docs/channels#contentDetails.relatedPlaylists
+      has_many :related_playlists
+
       # @!attribute [r] subscribed_channels
       #   @return [Yt::Collections::SubscribedChannels] the channels that this
       #     channel is subscribed to.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.3'
+  VERSION = '0.25.4'
 end

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -12,6 +12,7 @@ describe Yt::Account, :device_app do
 
   it { expect($account.channel).to be_a Yt::Channel }
   it { expect($account.playlists.first).to be_a Yt::Playlist }
+  it { expect($account.related_playlists.first).to be_a Yt::Playlist }
   it { expect($account.subscribed_channels.first).to be_a Yt::Channel }
   it { expect($account.user_info).to be_a Yt::UserInfo }
 

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -12,9 +12,29 @@ describe Yt::Account, :device_app do
 
   it { expect($account.channel).to be_a Yt::Channel }
   it { expect($account.playlists.first).to be_a Yt::Playlist }
-  it { expect($account.related_playlists.first).to be_a Yt::Playlist }
   it { expect($account.subscribed_channels.first).to be_a Yt::Channel }
   it { expect($account.user_info).to be_a Yt::UserInfo }
+
+  describe '.related_playlists' do
+    let(:related_playlists) { $account.related_playlists }
+
+    specify 'returns the list of associated playlist (Liked Videos, Uploads, ...)' do
+      expect(related_playlists.first).to be_a Yt::Playlist
+    end
+
+    specify 'includes public related playlists (such as Liked Videos)' do
+      uploads = related_playlists.select{|p| p.title.starts_with? 'Uploads'}
+      expect(uploads).not_to be_empty
+    end
+
+    specify 'includes private playlists (such as Watch Later or History)' do
+      watch_later = related_playlists.select{|p| p.title == 'Watch Later'}
+      expect(watch_later).not_to be_empty
+
+      history = related_playlists.select{|p| p.title == 'History'}
+      expect(history).not_to be_empty
+    end
+  end
 
   describe '.videos' do
     let(:video) { $account.videos.where(order: 'viewCount').first }

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -101,6 +101,7 @@ describe Yt::Channel, :device_app do
 
     it { expect(channel.playlists.first).to be_a Yt::Playlist }
     it { expect{channel.delete_playlists}.to raise_error Yt::Errors::RequestError }
+    it { expect(channel.related_playlists.first).to be_a Yt::Playlist }
 
     specify 'with a public list of subscriptions' do
       expect(channel.subscribed_channels.first).to be_a Yt::Channel

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -101,7 +101,24 @@ describe Yt::Channel, :device_app do
 
     it { expect(channel.playlists.first).to be_a Yt::Playlist }
     it { expect{channel.delete_playlists}.to raise_error Yt::Errors::RequestError }
-    it { expect(channel.related_playlists.first).to be_a Yt::Playlist }
+
+    describe '.related_playlists' do
+      let(:related_playlists) { channel.related_playlists }
+
+      specify 'returns the list of associated playlist (Liked Videos, Uploads, ...)' do
+        expect(related_playlists.first).to be_a Yt::Playlist
+      end
+
+      specify 'includes public related playlists (such as Liked Videos)' do
+        uploads = related_playlists.select{|p| p.title.starts_with? 'Uploads'}
+        expect(uploads).not_to be_empty
+      end
+
+      specify 'does not includes private playlists (such as Watch Later)' do
+        watch_later = related_playlists.select{|p| p.title.starts_with? 'Watch'}
+        expect(watch_later).to be_empty
+      end
+    end
 
     specify 'with a public list of subscriptions' do
       expect(channel.subscribed_channels.first).to be_a Yt::Channel

--- a/spec/requests/as_server_app/channel_spec.rb
+++ b/spec/requests/as_server_app/channel_spec.rb
@@ -21,6 +21,8 @@ describe Yt::Channel, :server_app do
     it { expect(channel.videos.first).to be_a Yt::Video }
     it { expect(channel.playlists).to be_a Yt::Collections::Playlists }
     it { expect(channel.playlists.first).to be_a Yt::Playlist }
+    it { expect(channel.related_playlists).to be_a Yt::Collections::Playlists }
+    it { expect(channel.related_playlists.first).to be_a Yt::Playlist }
 
     specify 'with a public list of subscriptions' do
       expect(channel.subscribed_channels.first).to be_a Yt::Channel


### PR DESCRIPTION
With related_playlists, you can retrieve special playlists associated
to a channel such as "Liked videos" or "Uploads"

Closes #218
