### PR TITLE
Set refresh token local variable also when Authenticatable is initialized with an authentication

### DIFF
--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -32,6 +32,10 @@ module Yt
         @force = options[:force]
         @scopes = options[:scopes]
         @authentication = options[:authentication]
+
+        if @refresh_token.nil? && @authentication
+          @refresh_token = @authentication.refresh_token
+        end
       end
 
       def auth


### PR DESCRIPTION
As mentioned in #226, when authenticating on behalf of content owner, the access token will not refresh using the refresh token because of the way the content owner object is initialized. This PR fixes that.

I'd like to add tests, but they won't run on my machine because of missing environment variables.
