### PR TITLE
Fix: print the right error on unauthorized client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.5 - 2015-08-12
+
+* [BUGIX] Correctly parse the YouTube response when requesting a refresh token with the wrong credentials.
+
 ## 0.25.4 - 2015-07-27
 
 * [FEATURE] Add `channel.related_playlist` and `account.related_playlists` to access "Liked Videos", "Uploads", etc.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.25.4'
+    gem 'yt', '~> 0.25.5'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/errors/request_error.rb
+++ b/lib/yt/errors/request_error.rb
@@ -20,7 +20,10 @@ module Yt
       end
 
       def reasons
-        kind.fetch('errors', []).map{|e| e['reason']}
+        case kind
+          when Hash then kind.fetch('errors', []).map{|e| e['reason']}
+          else kind
+        end
       end
 
     private

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.4'
+  VERSION = '0.25.5'
 end


### PR DESCRIPTION
Normally, when a request to YouTube API fails, YouTube responds with
a JSON body that includes a Hash inside the "error" key.

However, if your request is an authentication request to get a refresh
token, and the credentials are wrong, then YouTube just responds with:

``` json
{"error" : "unauthorized_client"}
```

In this case, the content of the `"error"` key is not a Hash but a
String, so we shouldn’t try to parse a Hash.
