### PR TITLE
Make Collections::Base fully enumerable

### DIFF
--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -6,8 +6,7 @@ require 'yt/config'
 module Yt
   module Actions
     module List
-      delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first,
-        :flat_map, :map, :select, :size, to: :list
+      delegate :each, :count, :size, to: :list
 
       def first!
         first.tap{|item| raise Errors::NoItems, error_message unless item}

--- a/lib/yt/collections/base.rb
+++ b/lib/yt/collections/base.rb
@@ -9,6 +9,7 @@ module Yt
       include Actions::DeleteAll
       include Actions::Insert
       include Actions::List
+      include Enumerable
 
       def initialize(options = {})
         @parent = options[:parent]


### PR DESCRIPTION
Stumbled upon `Yt::Collections::Base` not having `#reject`, but actually having `#select`. Same with `#map` but no `#collect` :unamused:

I believe it's reasonable to expect a fully `Enumerable` base collection. I checked the pulls and it seems to be a common request, with folks adding methods piecemeal.

I don't have any particular tests in mind for this. I'm sure I can provide some if you think it's worthwhile.
