### PR TITLE
Fix Video#update with publishAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.12 - 2015-12-03
+
+* [BUGFIX] Fix Video#update with publishAt
+
 ## 0.25.11 - 2015-11-05
 
 * [ENHANCEMENT] Add "youtube.com/v/..." as possible URL for YouTube videos

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.11'
+  VERSION = '0.25.12'
 end


### PR DESCRIPTION
If you look at this section in the documentation, publishAt works as follows:

If you set this property's value when calling the videos.update method, you must also set the status.privacyStatus property value to private even if the video is already private.
If your request schedules a video to be published at some time in the past, the video will be published right away. As such, the effect of setting the status.publishAt property to a past date and time is the same as of changing the video's privacyStatus from private to public.
