### PR TITLE
Fix eaca8df

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.13 - 2015-12-04
+
+* [BUGFIX] Fix previous fix to Video#update with publishAt (typo)
+
 ## 0.25.12 - 2015-12-03
 
 * [BUGFIX] Fix Video#update with publishAt

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -643,7 +643,7 @@ module Yt
             body_part[camelize key] = attributes.fetch key, public_send(name).public_send(key)
           end
 
-          if body_part.fetch(:publishAt, 1.day.from_now) < Time.now || body_part[:privacyStatus].in?(['public', 'unlisted'])
+          if (body_part[:publishAt] || 1.day.from_now) < Time.now || body_part[:privacyStatus].in?(['public', 'unlisted'])
             body_part.delete(:publishAt)
           end
         end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.12'
+  VERSION = '0.25.13'
 end


### PR DESCRIPTION
The previous fix to publishAt was wrong in that it would try to
compare a `nil` with a timestamp.
