### PR TITLE
Allow upload from IO stream

### DIFF
--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -60,16 +60,20 @@ module Yt
     ### ACTIONS ###
 
       # Uploads a video to the account’s channel.
-      # @param [String] path_or_url the video to upload. Can either be the
-      #   path of a local file or the URL of a remote file.
+      # @param [String] source the video to upload. Can either be the path of
+      #   a local file, the URL of a remote file or an IO-like object.
       # @param [Hash] params the metadata to add to the uploaded video.
       # @option params [String] :title The video’s title.
       # @option params [String] :description The video’s description.
       # @option params [Array<String>] :title The video’s tags.
       # @option params [String] :privacy_status The video’s privacy status.
       # @return [Yt::Models::Video] the newly uploaded video.
-      def upload_video(path_or_url, params = {})
-        file = open path_or_url, 'rb'
+      def upload_video(source, params = {})
+        file = if source.respond_to?(:read) && source.respond_to?(:eof?) && source.respond_to?(:size)
+                 source
+               else
+                 open source, 'rb'
+               end
         session = resumable_sessions.insert file.size, upload_body(params)
 
         session.update(body: file) do |data|

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -99,17 +99,24 @@ describe Yt::Account, :device_app do
 
   describe '.upload_video' do
     let(:video_params) { {title: 'Test Yt upload', privacy_status: 'private', category_id: 17} }
-    let(:video) { $account.upload_video path_or_url, video_params }
+    let(:video) { $account.upload_video source, video_params }
     after { video.delete }
 
     context 'given the path to a local video file' do
-      let(:path_or_url) { File.expand_path '../video.mp4', __FILE__ }
+      let(:source) { File.expand_path '../video.mp4', __FILE__ }
 
       it { expect(video).to be_a Yt::Video }
     end
 
     context 'given the URL of a remote video file' do
-      let(:path_or_url) { 'https://bit.ly/yt_test' }
+      let(:source) { 'https://bit.ly/yt_test' }
+
+      it { expect(video).to be_a Yt::Video }
+    end
+
+    context 'given an IO stream' do
+      after { source.close }
+      let(:source) { File.open(File.expand_path('../video.mp4', __FILE__), 'rb') }
 
       it { expect(video).to be_a Yt::Video }
     end


### PR DESCRIPTION
I needed it to stream from s3 to youtube.

Here is a complete example:

In the `Gemfile`:

``` ruby
source 'https://rubygems.org'

# AWS
gem 'aws-sdk', '~> 2'

# Youtube
gem 'yt', github: 'sinetris/yt', branch: 'upload_accept_io_streams'

# CLI
gem 'slop', '~> 4.2'
```

In `s3_to_youtube.rb`:

``` ruby
ENV['ENV'] ||= 'development'
Bundler.require :default, ENV['ENV']

ENV['AWS_REGION'] ||= 'eu-west-1'

module S3Helpers
  def client
    Aws::S3::Client.new
  end

  module_function :client
end

require 'forwardable'

class S3ObjectStream
  attr_reader :bucket, :key
  extend Forwardable

  alias :this_respond_to? :respond_to?

  delegate [*IO.instance_methods - %i(object_id __send__ __id__)] => :@reader

  def initialize(bucket:, key:)
    @bucket = bucket
    @key = key
    reader, writer = IO.pipe
    child_pid = fork do
      begin
        reader.close
        S3Helpers.client.get_object(bucket: bucket, key: key) do |chunk|
          writer.write(chunk)
        end
      ensure
        writer.close
        exit!
      end
    end
    writer.close
    at_exit do
      Process.kill(:TERM, child_pid) if child_pid
      reader.close unless reader.closed?
    end
    @reader = reader
  end

  def size
    @size ||= S3Helpers.client.head_object(bucket: bucket, key: key).content_length
  end

  def respond_to?(m)
    this_respond_to?(m) || super
  end
end

require 'slop'

opts = Slop.parse do |o|
  o.string '-b', '--bucket', 'an s3 bucket'
  o.string '-k', '--key', 'an s3 key'

  o.on '-h', '--help' do
    puts o
    exit
  end
end

unless opts.bucket? && opts.key?
  puts 'You must provide an s3 bucket and key'
  puts opts
  exit 1
end

source = S3ObjectStream.new(bucket: opts[:bucket], key: opts[:key])

account = Yt::Account.new refresh_token: ENV['YT_REFRESH_TOKEN']

yt_opts = {
  title: 'The title',
  privacy_status: 'unlisted'
}

video = account.upload_video(source, yt_opts)

puts video.inspect
```
## Usage

Installation:

``` sh
gem install bunder
bundle install
```

[Configure AWS](https://github.com/aws/aws-sdk-ruby#configuration) and [YT](https://github.com/Fullscreen/yt#configuring-with-environment-variables) and the `refresh_token` in `YT_REFRESH_TOKEN` environment variable, then execute:

``` sh
bundle exec ruby s3_to_youtube.rb -b my_bucket -k my_file.mp4
```
