### PR TITLE
Add `revoke_access` to Yt::Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.15 - 2015-12-17
+
+* [FEATURE] Add `revoke_access` to Yt::Account
+
 ## 0.25.14 - 2015-12-16
 
 * [ENHANCEMENT] Add `:display_name` to each content owner returned by account.content_owners

--- a/lib/yt/collections/revocations.rb
+++ b/lib/yt/collections/revocations.rb
@@ -1,0 +1,30 @@
+require 'yt/collections/authentications'
+require 'yt/models/revocation'
+
+module Yt
+  module Collections
+    class Revocations < Authentications
+      attr_accessor :auth_params
+
+    private
+
+      # This overrides the parent mehthod defined in Authentications
+      def attributes_for_new_item(data)
+        {data: data}
+      end
+
+      def list_params
+        super.tap do |params|
+          params[:host] = 'accounts.google.com'
+          params[:path] = '/o/oauth2/revoke'
+          params[:request_format] = nil
+          params[:method] = :get
+          params[:auth] = nil
+          params[:body] = nil
+          params[:camelize_body] = false
+          params[:params] = auth_params
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/models/revocation.rb
+++ b/lib/yt/models/revocation.rb
@@ -1,0 +1,12 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # @private
+    class Revocation < Base
+      def initialize(options = {})
+        @data = options[:data]
+      end
+    end
+  end
+end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.14'
+  VERSION = '0.25.15'
 end


### PR DESCRIPTION
Note that this feature is not currently tested in the specs since
this would require to generate a new token every time specs are run.
