### PR TITLE
Add access_token_was_refreshed to Yt::Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.16 - 2015-12-19
+
+* [FEATURE] Add `access_token_was_refreshed` to Yt::Account
+
 ## 0.25.15 - 2015-12-17
 
 * [FEATURE] Add `revoke_access` to Yt::Account

--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -58,7 +58,13 @@ module Yt
       def refreshed_access_token?
         old_access_token = authentication.access_token
         @authentication = @access_token = @refreshed_authentications = nil
-        old_access_token != authentication.access_token
+
+        if old_access_token != authentication.access_token
+          access_token_was_refreshed
+          true
+        else
+          false
+        end
       end
 
       # Revoke access given to the application.
@@ -71,6 +77,12 @@ module Yt
       rescue Errors::RequestError => e
         raise unless e.reasons.include? 'invalid_token'
         false
+      end
+
+      # Invoked when the access token is refreshed.
+      def access_token_was_refreshed
+        # Apps using Yt can override this method to handle this event, for
+        # instance to store the newly generated access token in the database.
       end
 
     private

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.15'
+  VERSION = '0.25.16'
 end


### PR DESCRIPTION
A new public method that can be overwritten by apps to "do something"
when the access token of an account is refreshed (e.g., store the
new access token in the database).
