### PR TITLE
Add :group_items to Yt::VideoGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.19 - 2016-01-15
+
+* [FEATURE] Add `:group_items` to Yt::VideoGroup (list items of a group)
+* [FEATURE] Add `:includes(:video)` to `Yt::VideoGroup#group_items` (eagerly loads all the videos)
+
 ## 0.25.18 - 2016-01-08
 
 * [FEATURE] Add Yt::COUNTRIES and Yt::US_STATES

--- a/lib/yt/collections/group_items.rb
+++ b/lib/yt/collections/group_items.rb
@@ -1,0 +1,44 @@
+require 'yt/collections/base'
+require 'yt/models/group_item'
+
+module Yt
+  module Collections
+    # @private
+    class GroupItems < Base
+
+    private
+
+      def attributes_for_new_item(data)
+        super(data).tap do |attributes|
+          attributes[:video] = data['video']
+        end
+      end
+
+      def list_params
+        super.tap do |params|
+          params[:path] = "/youtube/analytics/v1/groupItems"
+          params[:params] = {group_id: @parent.id}
+          if @auth.owner_name
+            params[:params][:on_behalf_of_content_owner] = @auth.owner_name
+          end
+        end
+      end
+
+      def eager_load_items_from(items)
+        if included_relationships.include?(:video)
+          all_video_ids = items.map{|item| item['resource']['id']}.uniq
+          all_video_ids.each_slice(50) do |video_ids|
+            conditions = {id: video_ids.join(',')}
+            conditions[:part] = 'snippet,status,statistics,contentDetails'
+            videos = Collections::Videos.new(auth: @auth).where conditions
+            items.each do |item|
+              video = videos.find{|v| v.id == item['resource']['id']}
+              item['video'] = video if video
+            end
+          end
+        end
+        super
+      end
+    end
+  end
+end

--- a/lib/yt/models/group_item.rb
+++ b/lib/yt/models/group_item.rb
@@ -1,0 +1,15 @@
+require 'yt/models/video'
+
+module Yt
+  module Models
+    class GroupItem < Base
+      attr_reader :auth, :data, :video
+
+      def initialize(options = {})
+        @data = options[:data]
+        @auth = options[:auth]
+        @video = options[:video] if options[:video]
+      end
+    end
+  end
+end

--- a/lib/yt/models/video_group.rb
+++ b/lib/yt/models/video_group.rb
@@ -24,6 +24,12 @@ module Yt
       #   @return [Time] the date and time when the group was created.
       delegate :published_at, to: :group_info
 
+    ### ASSOCIATIONS ###
+
+      # @!attribute [r] group_items
+      #   @return [Yt::Collections::GroupItems] the group’s items.
+      has_many :group_items
+
     ### ANALYTICS ###
 
       # @macro reports

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.18'
+  VERSION = '0.25.19'
 end

--- a/spec/requests/as_content_owner/video_group_spec.rb
+++ b/spec/requests/as_content_owner/video_group_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'yt/models/video_group'
+require 'yt/models/group_item'
 
 describe Yt::VideoGroup, :partner do
   subject(:video_group) { Yt::VideoGroup.new id: id, auth: $content_owner }
@@ -16,6 +17,18 @@ describe Yt::VideoGroup, :partner do
       specify 'the number of videos in the group can be retrieved' do
         expect(video_group.item_count).to be_an(Integer)
         expect(video_group.item_count).not_to be_zero
+      end
+
+      specify '.group_items retrieves the group items' do
+        expect(video_group.group_items.count).to be_an(Integer)
+        expect(video_group.group_items.map{|g| g}).to all(be_a Yt::GroupItem)
+      end
+
+      specify '.group_items.includes(:video) eager-loads each video' do
+        item = video_group.group_items.includes(:video).first
+        expect(item.video.instance_variable_defined? :@snippet).to be true
+        expect(item.video.instance_variable_defined? :@status).to be true
+        expect(item.video.instance_variable_defined? :@statistics_set).to be true
       end
 
       describe 'multiple reports can be retrieved at once' do


### PR DESCRIPTION
Also adds `:includes(:video)` to `Yt::VideoGroup#group_items` to eagerly
load all the videos of a group.
