### PR TITLE
Fix subscriptions list returning 0

### DIFF
--- a/lib/yt/collections/subscriptions.rb
+++ b/lib/yt/collections/subscriptions.rb
@@ -31,7 +31,6 @@ module Yt
       def subscriptions_params
         {}.tap do |params|
           params[:max_results] = 50
-          params[:for_channel_id] = @parent.id
           params[:mine] = true
           params[:part] = 'snippet'
         end


### PR DESCRIPTION
Adding `forChannelId` to subscriptions list request make it return 0.
Without the param it seems to work fine.

Haven't found a use case where both params where needed.
