### PR TITLE
Better deal with channels with > 500 videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.22 - 2016-02-04
+
+* [IMPROVEMENT] Deal with channels with more than 500 videos in a better way
+
 ## 0.25.21 - 2016-02-04
 
 * [BUGFIX] Add required 'require' to have `.with_indifferent_access` in geography

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.21'
+  VERSION = '0.25.22'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -86,6 +86,7 @@ describe Yt::Channel, :device_app do
           # of results to test that we can overcome YouTube’s limitation of only
           # returning the first 500 results when ordered by date.
           expect(channel.videos.count).to be > 500
+          expect(channel.videos.count).to eq channel.videos.map(&:id).uniq.count
           expect(channel.videos.where(order: 'viewCount').count).to be 500
         end
 


### PR DESCRIPTION
YouTube has changed the behavior of the API for channels with > 500 videos.
Rather than **not returing** a `nextPageToken`, it now returns one, but it's
a _broken_ one, with duplicate or missing results.

The new approach of YT is to simply switch to the `publishedBefore` way as
soon as 500 videos have been retrieved, since this is what YouTube documents.

This is still not perfect, since each page is cached by YouTube at different
times, and therefore some duplicates occur in successive pages. But it's better
than before, and all we can do without rebuilding YouTube.
