### PR TITLE
Fix: don’t retain pages for `videos.where(..)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.24 - 2016-03-02
+
+* [BUGFIX] When `videos.where(..)` returns more than one page, don’t retain the items for the next request.
+
 ## 0.25.23 - 2016-02-23
 
 * [IMPROVEMENT] Retry 3 times after a server error, to bypass temporary glitches by YouTube.

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -10,6 +10,7 @@ module Yt
     class Videos < Base
       def where(requirements = {})
         @published_before = nil
+        @halt_list = false
         super
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.23'
+  VERSION = '0.25.24'
 end


### PR DESCRIPTION
Fixes the case where you first call `channel.videos.where(..)` and the result
includes more than one page, then you call it again with a different `where`
conditions and the results are missing since `@halt_list` was still `true`.
