### PR TITLE
Add Yt::CommentThread model and related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.25 - 2016-03-24
+
+* [FEATURE] Add Yt::CommentThread resource.
+
 ## 0.25.24 - 2016-03-02
 
 * [BUGFIX] When `videos.where(..)` returns more than one page, don’t retain the items for the next request.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ Yt::PlaylistItem
 
 Check [fullscreen.github.io/yt](http://fullscreen.github.io/yt/playlist_items.html) for the list of methods available for `Yt::PlaylistItem`.
 
+Yt::CommentThread
+----------------
+
+Use [Yt::CommentThread](http://www.rubydoc.info/gems/yt/Yt/Models/CommentThread) to:
+
+* Show details of a comment_thread
+
+```ruby
+Yt::CommentThread.new id: 'z13vsnnbwtv4sbnug232erczcmi3wzaug'
+
+comment_thread.video_id #=> "1234"
+comment_thread.total_reply_count #=> 1
+comment_thread.can_reply? #=> true
+comment_thread.public? #=> true
+```
+
 Yt::Collections::Videos
 -----------------------
 

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -11,6 +11,7 @@ require 'yt/models/playlist'
 require 'yt/models/playlist_item'
 require 'yt/models/video'
 require 'yt/models/video_group'
+require 'yt/models/comment_thread'
 require 'yt/models/ownership'
 require 'yt/models/advertising_options_set'
 

--- a/lib/yt/models/comment_thread.rb
+++ b/lib/yt/models/comment_thread.rb
@@ -1,0 +1,30 @@
+require 'yt/models/resource'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube channels.
+    # @see https://developers.google.com/youtube/v3/docs/commentThreads
+    class CommentThread < Resource
+
+    ### SNIPPET ###
+
+      # @!attribute [r] video_id
+      #   @return [String] the ID of the video that the comments refer to, if
+      #   any. If this property is not present or does not have a value, then
+      #   the thread applies to the channel and not to a specific video.
+      delegate :video_id, to: :snippet
+
+      # @!attribute [r] total_reply_count
+      #   @return [String] The total number of replies that have been submitted 
+      #   in response to the top-level comment.
+      delegate :total_reply_count, to: :snippet
+
+      # @return [Boolean] whether the thread, including all of its comments and
+      # comment replies, is visible to all YouTube users.
+      delegate :public?, to: :snippet
+
+      # @return [Boolean] whether the current viewer can reply to the thread.
+      delegate :can_reply?, to: :snippet
+    end
+  end
+end

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -8,6 +8,7 @@ module Yt
     # @see https://developers.google.com/youtube/v3/docs/videos#resource
     # @see https://developers.google.com/youtube/v3/docs/playlists#resource
     # @see https://developers.google.com/youtube/v3/docs/playlistItems#resource
+    # @see https://developers.google.com/youtube/v3/docs/commentThread#resource
     class Snippet < Base
       attr_reader :data
 
@@ -28,9 +29,19 @@ module Yt
       has_attribute :position, type: Integer
       has_attribute :resource_id, default: {}
       has_attribute :thumbnails, default: {}
+      has_attribute :video_id
+      has_attribute :total_reply_count, type: Integer
 
       def thumbnail_url(size = :default)
         thumbnails.fetch(size.to_s, {})['url']
+      end
+
+      def public?
+        @public ||= data.fetch 'isPublic', false
+      end
+
+      def can_reply?
+        @can_reply ||= data.fetch 'canReply', false
       end
 
       # Returns whether YouTube API includes all attributes in this snippet.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.24'
+  VERSION = '0.25.25'
 end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'yt/models/comment_thread'
+
+describe Yt::CommentThread do
+  subject(:comment_thread) { Yt::CommentThread.new attrs }
+
+  describe '#snippet' do
+    context 'given fetching a comment thread returns a snippet' do
+      let(:attrs) { {snippet: {"videoId" => "12345"}} }
+      it { expect(comment_thread.snippet).to be_a Yt::Snippet }
+    end
+  end
+
+  describe '#video_id' do
+    context 'given a snippet with a video id' do
+      let(:attrs) { {snippet: {"videoId"=>"12345"}} }
+      it { expect(comment_thread.video_id).to eq '12345' }
+    end
+
+    context 'given a snippet without a video id' do
+      let(:attrs) { {snippet: {}} }
+      it { expect(comment_thread.video_id).to be_nil }
+    end
+  end
+
+  describe '#total_reply_count' do
+    context 'given a snippet with a total reply count' do
+      let(:attrs) { {snippet: {"totalReplyCount"=>1}} }
+      it { expect(comment_thread.total_reply_count).to eq 1 }
+    end
+
+    context 'given a snippet without a total reply count' do
+      let(:attrs) { {snippet: {}} }
+      it { expect(comment_thread.total_reply_count).to be_nil }
+    end
+  end
+
+  describe '#can_reply?' do
+    context 'given a snippet with canReply set' do
+      let(:attrs) { {snippet: {"canReply"=>true}} }
+      it { expect(comment_thread.can_reply?).to be true }
+    end
+
+    context 'given a snippet without canReply set' do
+      let(:attrs) { {snippet: {}} }
+      it { expect(comment_thread.can_reply?).to be false }
+    end
+  end
+
+  describe '#is_public?' do
+    context 'given a snippet with isPublic set' do
+      let(:attrs) { {snippet: {"isPublic"=>true}} }
+      it { expect(comment_thread).to be_public }
+    end
+
+    context 'given a snippet without isPublic set' do
+      let(:attrs) { {snippet: {}} }
+      it { expect(comment_thread).to_not be_public }
+    end
+  end
+end

--- a/spec/requests/as_server_app/comment_thread_spec.rb
+++ b/spec/requests/as_server_app/comment_thread_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'yt/models/comment_thread'
+
+describe Yt::CommentThread, :server_app do
+  subject(:comment_thread) { Yt::CommentThread.new attrs }
+
+  context 'given an existing comment thread ID about a channel' do
+    let(:attrs) { {id: 'z13vsnnbwtv4sbnug232erczcmi3wzaug'} }
+
+    it { expect(comment_thread.video_id).to be_nil }
+    it { expect(comment_thread.total_reply_count).to be_an Integer }
+    it { expect(comment_thread.can_reply?).to be false }
+    it { expect(comment_thread).to be_public }
+  end
+
+  context 'given an comment thread ID about a video' do
+    let(:attrs) { {id: 'z13ij10h2z3qxpcte23hc5oh2vfzeptk4'} }
+    it { expect(comment_thread.video_id).to be_a String }
+  end
+
+  context 'given an unknown comment thread ID' do
+    let(:attrs) { {id: 'not-a-comment-thread-id'} }
+    it { expect{comment_thread.total_reply_count}.to raise_error Yt::Errors::NoItems }
+  end
+
+end


### PR DESCRIPTION
This is an implementation of YouTube comment thread resource:

https://developers.google.com/youtube/v3/docs/commentThreads
