### PR TITLE
Add comment_threads (Yt::Collections::CommentThreads) association to video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.27 - 2016-03-28
+
+* [FEATURE] Add `comment_threads` association to Yt::Video.
+* [FEATURE] Add `top_level_comment` and delegate its attributes (`text_display`, `author_display_name`, `like_count`, `updated_at`) to Yt::CommentThread.
+
 ## 0.25.26 - 2016-03-24
 
 * [FEATURE] Add Yt::Comment resource.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ video.title #=> "Fullscreen Creator Platform"
 video.comment_count #=> 308
 video.hd? #=> true
 video.annotations.count #=> 1
+video.comment_threads #=> #<Yt::Collections::CommentThreads ...>
 ```
 
 The **full documentation** is available at [rubydoc.info](http://www.rubydoc.info/gems/yt/frames).
@@ -130,6 +131,12 @@ comment_thread.video_id #=> "1234"
 comment_thread.total_reply_count #=> 1
 comment_thread.can_reply? #=> true
 comment_thread.public? #=> true
+
+comment_thread.top_level_comment #=> #<Yt::Models::Comment ...>
+comment_thread.text_display #=> "funny video!"
+comment_thread.like_count #=> 9
+comment_thread.updated_at #=> 2016-03-22 12:56:56 UTC
+comment_thread.author_display_name #=> "Joe"
 ```
 
 Yt::Comment

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ video.comment_count #=> 308
 video.hd? #=> true
 video.annotations.count #=> 1
 video.comment_threads #=> #<Yt::Collections::CommentThreads ...>
+# Use #take to limit the number of pages need to fetch from server
+video.comment_threads.take(99).map(&:author_display_name) #=> ["Paul", "Tommy", ...]
 ```
 
 The **full documentation** is available at [rubydoc.info](http://www.rubydoc.info/gems/yt/frames).

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -6,7 +6,7 @@ require 'yt/config'
 module Yt
   module Actions
     module List
-      delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first,
+      delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first, :take,
         :flat_map, :map, :select, :size, to: :list
 
       def first!

--- a/lib/yt/collections/comment_threads.rb
+++ b/lib/yt/collections/comment_threads.rb
@@ -1,0 +1,41 @@
+require 'yt/collections/base'
+require 'yt/models/video'
+require 'yt/models/channel'
+
+module Yt
+  module Collections
+    # @private
+    class CommentThreads < Base
+
+    private
+
+      def attributes_for_new_item(data)
+        {}.tap do |attributes|
+          attributes[:id] = data['id']
+          attributes[:snippet] = data['snippet']
+          attributes[:auth] = @auth
+        end
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get the resource.
+      # @see https://developers.google.com/youtube/v3/docs/commentThreads#resource
+      def list_params
+        super.tap do |params|
+          params[:path] = "/youtube/v3/commentThreads"
+          params[:params] = comments_params
+        end
+      end
+
+      def comments_params
+        apply_where_params!({max_results: 100, part: 'snippet'}).tap do |params|
+          case @parent
+          when Yt::Video
+            params[:videoId] = @parent.id
+          when Yt::Channel
+            params[:channelId] = @parent.id
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/models/comment_thread.rb
+++ b/lib/yt/models/comment_thread.rb
@@ -2,21 +2,21 @@ require 'yt/models/resource'
 
 module Yt
   module Models
-    # Provides methods to interact with YouTube channels.
+    # Provides methods to interact with YouTube comment thread.
     # @see https://developers.google.com/youtube/v3/docs/commentThreads
     class CommentThread < Resource
 
     ### SNIPPET ###
 
       # @!attribute [r] video_id
-      #   @return [String] the ID of the video that the comments refer to, if
-      #   any. If this property is not present or does not have a value, then
-      #   the thread applies to the channel and not to a specific video.
+      #   @return [String] the ID of the video that the comment thread referto, if
+      #   any. If this property is not present or does not have a value, then the
+      #   thread applies to the channel and not to a specific video.
       delegate :video_id, to: :snippet
 
       # @!attribute [r] total_reply_count
       #   @return [String] The total number of replies that have been submitted 
-      #   in response to the top-level comment.
+      #   in response to the top level comment.
       delegate :total_reply_count, to: :snippet
 
       # @return [Boolean] whether the thread, including all of its comments and
@@ -25,6 +25,26 @@ module Yt
 
       # @return [Boolean] whether the current viewer can reply to the thread.
       delegate :can_reply?, to: :snippet
+
+      # @!attribute [r] top_level_comment
+      #   @return [Yt::TopLevelComment] the top level comment object.
+      delegate :top_level_comment, to: :snippet
+
+      # @!attribute [r] text_display
+      #   @return [String] the top level comment's display text.
+      delegate :text_display, to: :top_level_comment
+
+      # @!attribute [r] author_display_name
+      #   @return [String] the top level comment's author name.
+      delegate :author_display_name, to: :top_level_comment
+
+      # @!attribute [r] like_count
+      #   @return [String] the top level comment's likes count.
+      delegate :like_count, to: :top_level_comment
+
+      # @!attribute [r] updated_at
+      #   @return [String] the top level comment's last updated time.
+      delegate :updated_at, to: :top_level_comment
     end
   end
 end

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -1,4 +1,5 @@
 require 'yt/models/description'
+require 'yt/models/comment'
 
 module Yt
   module Models
@@ -38,7 +39,6 @@ module Yt
       has_attribute :like_count, type: Integer
       has_attribute :updated_at, type: Time
 
-
       def thumbnail_url(size = :default)
         thumbnails.fetch(size.to_s, {})['url']
       end
@@ -49,6 +49,17 @@ module Yt
 
       def can_reply?
         @can_reply ||= data.fetch 'canReply', false
+      end
+
+      def top_level_comment
+        if @top_level_comment.nil?
+          d = data.fetch('topLevelComment', nil).tap do |data|
+            data[:id] = data.fetch 'id', nil
+            data[:snippet] = data.fetch 'snippet', nil
+          end
+          @top_level_comment = Yt::Comment.new(d) if d
+        end
+        @top_level_comment
       end
 
       # Returns whether YouTube API includes all attributes in this snippet.

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -52,14 +52,7 @@ module Yt
       end
 
       def top_level_comment
-        if @top_level_comment.nil?
-          d = data.fetch('topLevelComment', nil).tap do |data|
-            data[:id] = data.fetch 'id', nil
-            data[:snippet] = data.fetch 'snippet', nil
-          end
-          @top_level_comment = Yt::Comment.new(d) if d
-        end
-        @top_level_comment
+        @top_level_comment ||= Yt::Comment.new data['topLevelComment'].symbolize_keys
       end
 
       # Returns whether YouTube API includes all attributes in this snippet.

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -369,6 +369,9 @@ module Yt
       delegate :concurrent_viewers, to: :live_streaming_detail
 
     ### ASSOCIATIONS ###
+      # @!attribute [r] comments
+      #   @return [Yt::Collections::Comments] the video’s comments.
+      has_many :comment_threads
 
       # @!attribute [r] annotations
       #   @return [Yt::Collections::Annotations] the video’s annotations.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.26'
+  VERSION = '0.25.27'
 end

--- a/spec/collections/comment_threads_spec.rb
+++ b/spec/collections/comment_threads_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'yt/collections/comment_threads'
+require 'yt/models/video'
+require 'yt/models/channel'
+
+describe Yt::Collections::CommentThreads do
+  subject(:collection) { Yt::Collections::CommentThreads.new parent: parent}
+
+  describe '#list_params' do
+    context "comment threads from a video" do
+      let(:parent) { Yt::Video.new id: 'any-id' }
+      it { expect(collection.send(:list_params)[:params]).to include :videoId }
+    end
+
+    context "comment threads from a video" do
+      let(:parent) { Yt::Channel.new id: 'any-id' }
+      it { expect(collection.send(:list_params)[:params]).to include :channelId }
+    end
+  end
+
+
+  describe '#size', :ruby2 do
+    describe 'sends only one request and return the total results' do
+      let(:total_results) { 1234 }
+      let(:parent) { Yt::Video.new id: 'any-id' }
+
+      before do
+        expect_any_instance_of(Yt::Request).to receive(:run).once do
+          double(body: {'pageInfo'=>{'totalResults'=>total_results}})
+        end
+      end
+      it { expect(collection.size).to be total_results }
+    end
+  end
+
+  describe '#count' do
+    let(:query) { {q: 'search string'} }
+    let(:parent) { Yt::Video.new id: 'any-id' }
+    let(:page) { {items: [], token: 'any-token'} }
+
+    context 'called once with .where(query) and once without' do
+      after do
+        collection.where(query).count
+        collection.count
+      end
+
+      it 'only applies the query on the first call' do
+        expect(collection).to receive(:fetch_page) do |options|
+          expect(options[:params]).to include query
+          page
+        end
+        expect(collection).to receive(:fetch_page) do |options|
+          expect(options[:params]).not_to include query
+          page
+        end
+      end
+    end
+  end
+end

--- a/spec/collections/comment_threads_spec.rb
+++ b/spec/collections/comment_threads_spec.rb
@@ -6,19 +6,6 @@ require 'yt/models/channel'
 describe Yt::Collections::CommentThreads do
   subject(:collection) { Yt::Collections::CommentThreads.new parent: parent}
 
-  describe '#list_params' do
-    context "comment threads from a video" do
-      let(:parent) { Yt::Video.new id: 'any-id' }
-      it { expect(collection.send(:list_params)[:params]).to include :videoId }
-    end
-
-    context "comment threads from a video" do
-      let(:parent) { Yt::Channel.new id: 'any-id' }
-      it { expect(collection.send(:list_params)[:params]).to include :channelId }
-    end
-  end
-
-
   describe '#size', :ruby2 do
     describe 'sends only one request and return the total results' do
       let(:total_results) { 1234 }

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -28,11 +28,6 @@ describe Yt::CommentThread do
       let(:attrs) { {snippet: {"topLevelComment"=> {}}} }
       it { expect(comment_thread.top_level_comment).to be_a Yt::Comment }
     end
-
-    context 'given a snippet without a top level comment' do
-      let(:attrs) { {snippet: {}} }
-      it { expect(comment_thread.top_level_comment).to be_nil }
-    end
   end
 
   describe 'attributes from #top_level_comment delegations' do

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -23,6 +23,43 @@ describe Yt::CommentThread do
     end
   end
 
+  describe '#top_level_comment' do
+    context 'given a snippet with a top level comment' do
+      let(:attrs) { {snippet: {"topLevelComment"=> {}}} }
+      it { expect(comment_thread.top_level_comment).to be_a Yt::Comment }
+    end
+
+    context 'given a snippet without a top level comment' do
+      let(:attrs) { {snippet: {}} }
+      it { expect(comment_thread.top_level_comment).to be_nil }
+    end
+  end
+
+  describe 'attributes from #top_level_comment delegations' do
+    context 'with values' do
+      let(:attrs) { {snippet: {"topLevelComment"=> {"id" => "xyz123", "snippet" => {
+        "textDisplay" => "funny video!",
+        "authorDisplayName" => "fullscreen",
+        "likeCount" => 99,
+        "updatedAt" => "2016-03-22T12:56:56.3Z"}}}} }
+
+      it { expect(comment_thread.top_level_comment.id).to eq 'xyz123' }
+      it { expect(comment_thread.text_display).to eq 'funny video!' }
+      it { expect(comment_thread.author_display_name).to eq 'fullscreen' }
+      it { expect(comment_thread.like_count).to eq 99 }
+      it { expect(comment_thread.updated_at).to eq Time.parse('2016-03-22T12:56:56.3Z') }
+    end
+
+    context 'without values' do
+      let(:attrs) { {snippet: {"topLevelComment"=> {"snippet" => {}}}} }
+
+      it { expect(comment_thread.text_display).to be_nil }
+      it { expect(comment_thread.author_display_name).to be_nil }
+      it { expect(comment_thread.like_count).to be_nil }
+      it { expect(comment_thread.updated_at).to be_nil }
+    end
+  end
+
   describe '#total_reply_count' do
     context 'given a snippet with a total reply count' do
       let(:attrs) { {snippet: {"totalReplyCount"=>1}} }

--- a/spec/requests/as_server_app/comment_thread_spec.rb
+++ b/spec/requests/as_server_app/comment_thread_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'yt/models/comment_thread'
+require 'yt/models/comment'
 
 describe Yt::CommentThread, :server_app do
   subject(:comment_thread) { Yt::CommentThread.new attrs }
@@ -11,6 +12,12 @@ describe Yt::CommentThread, :server_app do
     it { expect(comment_thread.total_reply_count).to be_an Integer }
     it { expect(comment_thread.can_reply?).to be false }
     it { expect(comment_thread).to be_public }
+
+    it { expect(comment_thread.top_level_comment).to be_a Yt::Comment }
+    it { expect(comment_thread.text_display).not_to be_empty }
+    it { expect(comment_thread.author_display_name).not_to be_empty }
+    it { expect(comment_thread.updated_at).to be_a Time }
+    it { expect(comment_thread.like_count).to be_a Integer }
   end
 
   context 'given an comment thread ID about a video' do

--- a/spec/requests/as_server_app/comment_threads_spec.rb
+++ b/spec/requests/as_server_app/comment_threads_spec.rb
@@ -1,0 +1,41 @@
+# encoding: UTF-8
+require 'spec_helper'
+require 'yt/collections/comment_threads'
+require 'yt/models/video'
+require 'yt/models/channel'
+
+describe Yt::Collections::CommentThreads, :server_app do
+  context "without parent association", :ruby2 do
+    subject(:comment_threads) { Yt::Collections::CommentThreads.new }
+
+    specify 'without given any of id, videoId, channelId or allThreadsRelatedToChannelId param, raise request error', :ruby2 do
+      expect{ comment_threads.size }.to raise_error(Yt::Errors::RequestError)
+    end
+
+    specify 'with a id param, only return one comment thread' do
+      expect(comment_threads.where(id: 'z13zytsilxbexh30e233gdyyttngfjfz104').size).to eq 1
+    end
+
+    specify 'with a videoId param, returns comment threads for the video', focus: true do
+      expect(comment_threads.where(videoId: 'MsplPPW7tFo').size).to be > 0
+    end
+
+    specify 'with a channelId param, returns comment threads for the channel' do
+      expect(comment_threads.where(channelId: 'UC-lHJZR3Gqxm24_Vd_AJ5Yw').size).to be > 0
+    end
+  end
+
+  context "with parent association", :ruby2 do
+    subject(:comment_threads) { Yt::Collections::CommentThreads.new parent: parent}
+
+    context "parent as video" do
+      let(:parent) { Yt::Models::Video.new id: 'MsplPPW7tFo' }
+      it { expect(comment_threads.size).to be > 0 }
+    end
+
+    context "parent as channel" do
+      let(:parent) { Yt::Models::Channel.new id: 'UC-lHJZR3Gqxm24_Vd_AJ5Yw' }
+      it { expect(comment_threads.size).to be > 0 }
+    end
+  end
+end

--- a/spec/requests/as_server_app/video_spec.rb
+++ b/spec/requests/as_server_app/video_spec.rb
@@ -6,7 +6,7 @@ describe Yt::Video, :server_app do
   subject(:video) { Yt::Video.new attrs }
 
   context 'given an existing video ID' do
-    let(:attrs) { {id: 'MESycYJytkU'} }
+    let(:attrs) { {id: 'L3JDXvz7G6c'} }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -28,11 +28,11 @@ describe Yt::Video, :server_app do
   end
 
   context 'given an existing video URL' do
-    let(:attrs) { {url: 'https://www.youtube.com/watch?v=MESycYJytkU&list=LLxO1tY8h1AhOz0T4ENwmpow'} }
+    let(:attrs) { {url: 'https://www.youtube.com/watch?v=L3JDXvz7G6c'} }
 
     specify 'provides access to its data' do
-      expect(video.id).to eq 'MESycYJytkU'
-      expect(video.title).to eq 'Fullscreen Creator Platform'
+      expect(video.id).to eq 'L3JDXvz7G6c'
+      expect(video.title).to eq "you’re in fullscreen"
       expect(video.privacy_status).to eq 'public'
     end
   end

--- a/spec/requests/as_server_app/video_spec.rb
+++ b/spec/requests/as_server_app/video_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'yt/models/video'
+require 'yt/collections/comment_threads'
 
 describe Yt::Video, :server_app do
   subject(:video) { Yt::Video.new attrs }
@@ -55,4 +56,24 @@ describe Yt::Video, :server_app do
     end
   end
 
+  describe 'associations' do
+    let(:attrs) { {id: 'MsplPPW7tFo'} }
+
+    describe '#comment_threads' do
+      it { expect(video.comment_threads).to be_a Yt::Collections::CommentThreads }
+      it { expect(video.comment_threads.first.top_level_comment).to be_a Yt::Models::Comment }
+    end
+
+    describe '#comment_threads.each_cons' do
+      it {
+        comment_threads = []
+        video.comment_threads.each_cons(2).take_while do |items|
+          comment_threads += items
+          comment_threads.size < 6
+        end
+        expect(comment_threads.size).to be 6
+      }
+    end
+  end
 end
+

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -22,7 +22,7 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   specify 'with a chart parameter, only returns videos of that chart', :ruby2 do
-    expect(videos.where(chart: 'mostPopular').size).to be 30
+    expect(videos.where(chart: 'mostPopular').size).to be 200
   end
 
   context 'with a list of parts' do


### PR DESCRIPTION
With this update, the following becomes possible:

``` ruby
# Association
video = Yt::Video.new id: 'fNS4lecOaAc'
all_text = video.comment_threads.map do |ct|
  ct.text_display # or ct.top_level_comment.text_display
end

# Yt::Collections::CommentThreads
comments = Yt::Collections::CommentThreads.new
all_text = comments.where(videoId: 'fNS4lecOaAc').map do |ct|
  ct.text_display # or ct.top_level_comment.text_display
end
```
