### PR TITLE
Asset search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.28 - 2016-04-05
+
+* [BUGFIX] If no asset ID is set, calling ContentOwner#assets will now use the path, /youtube/partner/v1/assetSearch, instead of '/youtube/partner/v1/assets'
+
 ## 0.25.27 - 2016-03-28
 
 * [FEATURE] Add `comment_threads` association to Yt::Video.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Use [Yt::ContentOwner](http://www.rubydoc.info/gems/yt/Yt/Models/ContentOwner) t
 * list and delete the references administered by the content owner
 * list the policies and policy rules administered by the content owner
 * create assets
+* list assets
 
 ```ruby
 # Content owners can be initialized with access token, refresh token or an authorization code
@@ -95,6 +96,13 @@ content_owner.policies.first.rules.first.action #=> "monetize"
 content_owner.policies.first.rules.first.included_territories #=> ["US", "CA"]
 
 content_owner.create_asset type: 'web' #=> #<Yt::Models::Asset @id=...>
+
+content_owner.assets.first #=> #<Yt::Models::AssetSnippet:0x007ff2bc543b00 @id=...>
+content_owner.assets.first.id #=> "A4532885163805730"
+content_owner.assets.first.title #=> "Money Train"
+content_owner.assets.first.type #=> "web"
+content_owner.assets.first.custom_id #=> "MoKNJFOIRroc"
+
 ```
 
 *All the above methods require authentication (see below).*

--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -39,7 +39,7 @@ module Yt
       #   is accessed; it should be replaced with a filter on params instead.
       def assets_path
         @where_params ||= {}
-        if @where_params.empty? || @where_params.key?(:id)
+        if @where_params.key?(:id)
           '/youtube/partner/v1/assets'
         else
           '/youtube/partner/v1/assetSearch'

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.27'
+  VERSION = '0.25.28'
 end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -279,6 +279,19 @@ describe Yt::ContentOwner, :partner do
     end
   end
 
+  describe '.assets' do
+    describe 'given the content owner has assets' do
+      let(:asset) { $content_owner.assets.first }
+
+      it 'returns valid asset' do
+        expect(asset.id).to be_a String
+        expect(asset.type).to be_a String
+        expect(asset.title).to be_a String
+        expect(asset.custom_id).to be_a String
+      end
+    end
+  end
+
   # @note: The following test works, but YouTube API endpoint to mark
   #   an asset as 'invalid' (soft-delete) does not work, and apparently
   #   there is no way to update the status of a asset.


### PR DESCRIPTION
Currently, if asset ID was never set when instantiating `Yt::ContentOwner`, calling #assets would still use the path,  /youtube/partner/v1/assets. Unfortunately that would not work because that endpoint expects an asset ID. So this should fix where if the asset ID was never set, it will use the path, /youtube/partner/v1/assetSearch, otherwise it will continue to use the path, /youtube/partner/v1/assets.
