### PR TITLE
Youtube has more than one types of rate limits, so 'Exceeded' should cover more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.29 - 2016-04-07
+
+* [BUGFIX] Previously, Yt was throttling queries for `quotaExceeded` responses from YouTube. However, matching `quotaExceeded` was too specific and would not have caught other limit exceeding responses from YouTube. This change will allow Yt to throttle other responses that contains `Exceeded` or `exceeded`.
+
 ## 0.25.28 - 2016-04-05
 
 * [BUGFIX] If no asset ID is set, calling ContentOwner#assets will now use the path, /youtube/partner/v1/assetSearch, instead of '/youtube/partner/v1/assets'

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -269,7 +269,7 @@ module Yt
 
     # @return [Boolean] whether the request exceeds the YouTube quota
     def exceeded_quota?
-      response_error == Errors::Forbidden && response.body =~ /Exceeded/
+      response_error == Errors::Forbidden && response.body =~ /Exceeded/i
     end
 
     # @return [Boolean] whether the request lacks proper authorization.

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -269,7 +269,7 @@ module Yt
 
     # @return [Boolean] whether the request exceeds the YouTube quota
     def exceeded_quota?
-      response_error == Errors::Forbidden && response.body =~ /quotaExceeded/
+      response_error == Errors::Forbidden && response.body =~ /Exceeded/
     end
 
     # @return [Boolean] whether the request lacks proper authorization.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.28'
+  VERSION = '0.25.29'
 end


### PR DESCRIPTION
Previously, "quotaExceeded" was too specific, so "Exceeded" should cover more of youtube's rate limit errors.
