### PR TITLE
Keep :claim, :category in included_relationships, ignore it if neccessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 0.25.32 - 2016-04-11
+## 0.25.32 - 2016-04-12
 
 * [BUGFIX] Fix where videos did not eager load claims or categories in subsequent requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.32 - 2016-04-11
+
+* [BUGFIX] Fix where videos did not eager load claims or categories in subsequent requests.
+
 ## 0.25.31 - 2016-04-11
 
 * [BUGFIX] Don’t try to instantiate video.claim if a video does not have a claim.

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -33,13 +33,15 @@ module Yt
 
       def eager_load_items_from(items)
         if included_relationships.any?
-          include_category = included_relationships.delete(:category)
-          include_claim = included_relationships.delete(:claim)
-          included_relationships.append(:snippet).uniq! if include_category || include_claim
+          included_relationships.append(:snippet).uniq! if
+            included_relationships.include?(:claim) ||
+            included_relationships.include?(:category)
 
           ids = items.map{|item| item['id']['videoId']}
-          parts = included_relationships.map{|r| r.to_s.camelize(:lower)}
-          conditions = {id: ids.join(','), part: parts.join(',')}
+          parts = included_relationships.reject do |p|
+            p == :claim || p == :category
+          end.map{|r| r.to_s.camelize(:lower)}
+          conditions = { id: ids.join(','), part: parts.join(',') }
           videos = Collections::Videos.new(auth: @auth).where conditions
 
           items.each do |item|
@@ -54,7 +56,7 @@ module Yt
             end if video
           end
 
-          if include_claim
+          if included_relationships.include? :claim
             video_ids = items.map{|item| item['id']['videoId']}.uniq
             conditions = { video_id: video_ids.join(',') }
             claims = @parent.claims.where conditions
@@ -64,7 +66,7 @@ module Yt
             end
           end
 
-          if include_category
+          if included_relationships.include? :category
             category_ids = items.map{|item| item['snippet']['categoryId']}.uniq
             conditions = {id: category_ids.join(',')}
             video_categories = Collections::VideoCategories.new(auth: @auth).where conditions

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -33,14 +33,15 @@ module Yt
 
       def eager_load_items_from(items)
         if included_relationships.any?
-          included_relationships.append(:snippet).uniq! if
-            included_relationships.include?(:claim) ||
-            included_relationships.include?(:category)
+          associations = [:claim, :category]
+          if (included_relationships & associations).any?
+            included_relationships.append(:snippet).uniq!
+          end
 
           ids = items.map{|item| item['id']['videoId']}
-          parts = included_relationships.reject do |p|
-            p == :claim || p == :category
-          end.map{|r| r.to_s.camelize(:lower)}
+          parts = (included_relationships - associations).map do |r|
+            r.to_s.camelize(:lower)
+          end
           conditions = { id: ids.join(','), part: parts.join(',') }
           videos = Collections::Videos.new(auth: @auth).where conditions
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.31'
+  VERSION = '0.25.32'
 end


### PR DESCRIPTION
So a problem we had was that claims and video_category were only being eager loaded for the first videos API call. Subsequent lazily loaded videos did not eager load the associated claims or categories. It happened because we deleted the `:video` and `:category` to prevent it from being included in `parts`, but it was never added back in.

So we keep `:claim` and `:category` in the the array, `included_relationships`. In `parts`, we reject the `:claim` and `:category` so that it doesn't get passed into the parts params.
