### PR TITLE
Video eagerload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.33 - 2016-04-15
+
+* [FEATURE] Eager-loading claims from videos will also eager-load assets.
+* [FEATURE] New method - `Claim#source` will return the source of the claim.
+
 ## 0.25.32 - 2016-04-12
 
 * [BUGFIX] Fix where videos did not eager load claims or categories in subsequent requests.

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -17,6 +17,27 @@ module Yt
 
     private
 
+      def attributes_for_new_item(data)
+        {}.tap do |attributes|
+          attributes[:id] = data['id']
+          attributes[:auth] = @auth
+          attributes[:data] = data
+          attributes[:asset] = data['asset']
+        end
+      end
+
+      def eager_load_items_from(items)
+        if included_relationships.include? :asset
+          asset_ids = items.map { |item| item['assetId'] }.uniq
+          conditions = { id: asset_ids.join(','), fetch_metadata: 'effective' }
+          assets = @parent.assets.where conditions
+          items.each do |item|
+            item['asset'] = assets.find { |a| a.id == item['assetId'] }
+          end
+        end
+        super
+      end
+
       # @return [Hash] the parameters to submit to YouTube to list claims
       #   administered by the content owner.
       # @see https://developers.google.com/youtube/partner/docs/v1/claims/list

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -33,7 +33,7 @@ module Yt
 
       def eager_load_items_from(items)
         if included_relationships.any?
-          associations = [:claim, :category, { claim: :asset }]
+          associations = [:claim, :category]
           if (included_relationships & associations).any?
             included_relationships.append(:snippet).uniq!
           end
@@ -57,19 +57,13 @@ module Yt
             end if video
           end
 
-          eager_load_claim = included_relationships.include? :claim
-          eager_load_asset = included_relationships.include?({ claim: :asset })
-          if eager_load_claim || eager_load_asset
+          if included_relationships.include? :claim
             video_ids = items.map{|item| item['id']['videoId']}.uniq
             conditions = {
               video_id: video_ids.join(','),
               include_third_party_claims: false
             }
-            if eager_load_asset
-              claims = @parent.claims.includes(:asset).where conditions
-            else
-              claims = @parent.claims.where conditions
-            end
+            claims = @parent.claims.includes(:asset).where conditions
             items.each do |item|
               claim = claims.find { |c| c.video_id == item['id']['videoId']}
               item['claim'] = claim

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -61,7 +61,10 @@ module Yt
           eager_load_asset = included_relationships.include?({ claim: :asset })
           if eager_load_claim || eager_load_asset
             video_ids = items.map{|item| item['id']['videoId']}.uniq
-            conditions = { video_id: video_ids.join(',') }
+            conditions = {
+              video_id: video_ids.join(','),
+              include_third_party_claims: false
+            }
             if eager_load_asset
               claims = @parent.claims.includes(:asset).where conditions
             else

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -114,12 +114,12 @@ module Yt
         content_type == 'audiovisual'
       end
 
-      # @return [Yt::Models::Claim] the source of the claim
+      # @return [String] the source of the claim
       def source
         @data.fetch('origin', {})['source']
       end
 
-      # @return [Yt::Models::Claim] the asset of the claim
+      # @return [Yt::Models::Asset] the asset of the claim
       def asset
         @asset
       end

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -11,6 +11,7 @@ module Yt
         @data = options[:data]
         @id = options[:id]
         @auth = options[:auth]
+        @asset = options[:asset] if options[:asset]
       end
 
       # @!attribute [r] claim_history
@@ -117,6 +118,11 @@ module Yt
       def source
         origin = @data.fetch 'origin', nil
         origin.fetch 'source', nil if origin
+      end
+
+      # @return the first asset of the claim.
+      def asset
+        @asset
       end
 
       # @return [Time] the date and time that the claim was created.

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -113,6 +113,11 @@ module Yt
         content_type == 'audiovisual'
       end
 
+      def source
+        origin = @data.fetch 'origin', nil
+        origin.fetch 'source', nil if origin
+      end
+
       # @return [Time] the date and time that the claim was created.
       has_attribute :created_at, type: Time, from: :time_created
 

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -113,6 +113,7 @@ module Yt
         content_type == 'audiovisual'
       end
 
+      # @return String of the claim's source.
       def source
         origin = @data.fetch 'origin', nil
         origin.fetch 'source', nil if origin

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -114,13 +114,12 @@ module Yt
         content_type == 'audiovisual'
       end
 
-      # @return String of the claim's source.
+      # @return [Yt::Models::Claim] the source of the claim
       def source
-        origin = @data.fetch 'origin', nil
-        origin.fetch 'source', nil if origin
+        @data.fetch('origin', {})['source']
       end
 
-      # @return the first asset of the claim.
+      # @return [Yt::Models::Claim] the asset of the claim
       def asset
         @asset
       end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.32'
+  VERSION = '0.25.33'
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -208,4 +208,16 @@ describe Yt::Claim do
       it { expect(claim.third_party?).to be false }
     end
   end
+
+  describe '#source' do
+    context 'given fetching a claim returns a source' do
+      let(:data) { {"origin"=>{"source"=>"webUpload"}} }
+      it { expect(claim.source).to eq 'webUpload' }
+    end
+
+    context 'given fetching a claim does not return a source' do
+      let(:data) { {"origin"=>{}} }
+      it { expect(claim.source).to eq nil }
+    end
+  end
 end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -60,6 +60,18 @@ describe Yt::ContentOwner, :partner do
         expect(video_with_claim.claim.video_id).to eq video_with_claim.id
       end
     end
+
+    describe '.includes(claim: :asset)' do
+      let(:videos) { $content_owner.videos.includes(claim: :asset) }
+      let(:video_with_claim_with_asset) do
+        videos.find{|v| v.try(:claim).try(:asset)}
+      end
+
+      specify 'eager-loads asset of each claim' do
+        expect(video_with_claim_with_asset.claim.asset).to be_a Yt::Asset
+        expect(video_with_claim_with_asset.claim.asset.id).to be_a String
+      end
+    end
   end
 
   describe '.video_groups' do

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -53,19 +53,13 @@ describe Yt::ContentOwner, :partner do
     describe '.includes(:claim)' do
       let(:videos) { $content_owner.videos.includes(:claim) }
       let(:video_with_claim) { videos.find{|v| v.claim.present?} }
-      let(:video_with_claim_with_asset) do
-        videos.find{|v| v.try(:claim).try(:asset)}
-      end
 
-      specify 'eager-loads the claim of each video' do
+      specify 'eager-loads the claim of each video and its asset' do
         expect(video_with_claim.claim).to be_a Yt::Claim
         expect(video_with_claim.claim.id).to be_a String
         expect(video_with_claim.claim.video_id).to eq video_with_claim.id
-      end
-
-      specify 'eager-loads asset of each claim' do
-        expect(video_with_claim_with_asset.claim.asset).to be_a Yt::Asset
-        expect(video_with_claim_with_asset.claim.asset.id).to be_a String
+        expect(video_with_claim.claim.asset).to be_a Yt::Asset
+        expect(video_with_claim.claim.asset.id).to be_a String
       end
     end
   end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -53,18 +53,14 @@ describe Yt::ContentOwner, :partner do
     describe '.includes(:claim)' do
       let(:videos) { $content_owner.videos.includes(:claim) }
       let(:video_with_claim) { videos.find{|v| v.claim.present?} }
+      let(:video_with_claim_with_asset) do
+        videos.find{|v| v.try(:claim).try(:asset)}
+      end
 
       specify 'eager-loads the claim of each video' do
         expect(video_with_claim.claim).to be_a Yt::Claim
         expect(video_with_claim.claim.id).to be_a String
         expect(video_with_claim.claim.video_id).to eq video_with_claim.id
-      end
-    end
-
-    describe '.includes(claim: :asset)' do
-      let(:videos) { $content_owner.videos.includes(claim: :asset) }
-      let(:video_with_claim_with_asset) do
-        videos.find{|v| v.try(:claim).try(:asset)}
       end
 
       specify 'eager-loads asset of each claim' do


### PR DESCRIPTION
These changes add:
- `$content_owner.videos.includes(:claim)` will so eager-load assets. Allowing you to do this: `$content_owner.videos.includes(:claim).first.claim.asset.id`.
- Add `Claim#source` that returns the source of the claim.
