### PR TITLE
Don’t eager load more than 50 assets at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.35  - 2016-04-27
+
+* [BUGFIX] Don’t try to eager load more than 50 assets at the time from claims
+
 ## 0.25.34  - 2016-04-20
 
 * [FEATURE] Add `ad_breaks` and `tp_ad_server_video_id` attribute to AdvertisingOptionsSet

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -28,7 +28,7 @@ module Yt
 
       def eager_load_items_from(items)
         if included_relationships.include? :asset
-          asset_ids = items.map { |item| item['assetId'] }.uniq
+          asset_ids = items.map{|a| a.values_at 'videoId', 'assetId'}.to_h.values
           conditions = { id: asset_ids.join(','), fetch_metadata: 'effective' }
           assets = @parent.assets.where conditions
           items.each do |item|

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.34'
+  VERSION = '0.25.35'
 end


### PR DESCRIPTION
Calling `content_owner.videos.inclue(:claim)` will result in a first query that
loads 50 videos of the content owner, then a second query that will load all
the claims for those videos, then a third query to fetch the asset of each claim.

The problem is that there can be _more than one claim on each video_ by the
same content owner.

For instance, we can fetch 50 videos, then when we fetch claims we get 51.
At that point, if we pass the 51 claim IDs to fetch the assets, we get an error:

```
{"class"=>"RequestError", "errors"=>[{"domain"=>"global", "reason"=>"invalid", "message"=>"The number of asset IDs you provided is too large. You may only list up to 50 assets per request.", "locationType"=>"parameter", "location"=>"id"}], "code"=>400, "message"=>"The number of asset IDs you provided is too large. You may only list up to 50 assets per request."}
```

To fix this, we assume that a user who is eager-loading video > claim > asset
will be happy just loading _one_ claim per video. If that's not the case, then
the user should not use eager-loading.
