### PR TITLE
Update conditions to not raise error in authentications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+
+## 0.25.36  - 2016-05-10
+
+* [BUGFIX] Raise RequestError when authentication code is "invalid" or "already redeemed"
+* [FEATURE] Make two methods `#explanation` and `#response_body` public for `Yt::Errors::RequestError`
+
 ## 0.25.35  - 2016-04-27
 
 * [BUGFIX] Don’t try to eager load more than 50 assets at the time from claims

--- a/lib/yt/collections/authentications.rb
+++ b/lib/yt/collections/authentications.rb
@@ -40,7 +40,14 @@ module Yt
       end
 
       def expected?(error)
-        error.kind == 'invalid_grant'
+        error.kind == 'invalid_grant' &&
+          invalid_code_errors.exclude?(error.description)
+      end
+
+    private
+
+      def invalid_code_errors
+        ["Code was already redeemed.", "Invalid code."]
       end
     end
   end

--- a/lib/yt/errors/forbidden.rb
+++ b/lib/yt/errors/forbidden.rb
@@ -3,8 +3,6 @@ require 'yt/errors/request_error'
 module Yt
   module Errors
     class Forbidden < RequestError
-      private
-
       def explanation
         'A request to YouTube API was considered forbidden by the server'
       end

--- a/lib/yt/errors/no_items.rb
+++ b/lib/yt/errors/no_items.rb
@@ -3,8 +3,6 @@ require 'yt/errors/request_error'
 module Yt
   module Errors
     class NoItems < RequestError
-      private
-
       def explanation
         'A request to YouTube API returned no items but some were expected'
       end

--- a/lib/yt/errors/request_error.rb
+++ b/lib/yt/errors/request_error.rb
@@ -30,12 +30,15 @@ module Yt
         end
       end
 
-    private
-
       def explanation
         'A request to YouTube API failed'
       end
 
+      def response_body
+        json['response_body'].is_a?(Hash) ? json['response_body'] : {}
+      end
+
+    private
 
       def details
         <<-MSG.gsub(/^ {8}/, '')
@@ -58,10 +61,6 @@ module Yt
       end
 
       def more_details
-      end
-
-      def response_body
-        json['response_body'].is_a?(Hash) ? json['response_body'] : {}
       end
 
       def request_curl

--- a/lib/yt/errors/request_error.rb
+++ b/lib/yt/errors/request_error.rb
@@ -19,6 +19,10 @@ module Yt
         response_body.fetch 'error', {}
       end
 
+      def description
+        response_body.fetch 'error_description', {}
+      end
+
       def reasons
         case kind
           when Hash then kind.fetch('errors', []).map{|e| e['reason']}

--- a/lib/yt/errors/server_error.rb
+++ b/lib/yt/errors/server_error.rb
@@ -3,8 +3,6 @@ require 'yt/errors/request_error'
 module Yt
   module Errors
     class ServerError < RequestError
-      private
-
       def explanation
         'A request to YouTube API caused an unexpected server error'
       end

--- a/lib/yt/errors/unauthorized.rb
+++ b/lib/yt/errors/unauthorized.rb
@@ -4,11 +4,11 @@ require 'yt/config'
 module Yt
   module Errors
     class Unauthorized < RequestError
-      private
-
       def explanation
         'A request to YouTube API was sent without a valid authentication'
       end
+
+    private
 
       def more_details
         if [Yt.configuration.client_id, Yt.configuration.api_key].none?

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.35'
+  VERSION = '0.25.36'
 end


### PR DESCRIPTION
to not retry authentication code in case "already redeemed" or "invalid", involving the error description value in `expected?`

```
{
  "error" : "invalid_grant",
  "error_description" : "Code was already redeemed."
}
```

```
{
  "error" : "invalid_grant",
  "error_description" : "Invalid code."
}
```

And make private methods `explanation` and `response_body` under RequestError into public 
