### PR TITLE
Add missing Channel fields

### DIFF
--- a/lib/yt/collections/channels.rb
+++ b/lib/yt/collections/channels.rb
@@ -11,6 +11,7 @@ module Yt
 
       def attributes_for_new_item(data)
         super(data).tap do |attributes|
+          attributes[:content_details] = data['contentDetails']
           attributes[:statistics] = data['statistics']
         end
       end

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -16,6 +16,14 @@ module Yt
       #   @return [String] the channel’s description.
       delegate :description, to: :snippet
 
+      # @!attribute [r] custom_url
+      #   @return [String] the channel’s custom URL.
+      delegate :custom_url, to: :snippet
+
+      # @!attribute [r] country
+      #   @return [String] the country with which the channel is associated.
+      delegate :country, to: :snippet
+
       # @!method thumbnail_url(size = :default)
       #   Returns the URL of the channel’s thumbnail.
       #   @param [Symbol, String] size The size of the channel’s thumbnail.

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -37,6 +37,13 @@ module Yt
       #   @return [Time] the date and time that the channel was created.
       delegate :published_at, to: :snippet
 
+    ### CONTENT DETAILS ###
+      has_one :content_detail
+
+      # @!attribute [r] google_plus_user_id
+      #   @return [String] the Google+ profile ID associated with this channel.
+      delegate :google_plus_user_id, to: :content_detail
+
     ### SUBSCRIPTION ###
 
       has_one :subscription
@@ -264,6 +271,9 @@ module Yt
       # if the response includes them
       def initialize(options = {})
         super options
+        if options[:content_details]
+          @content_detail = ContentDetail.new data: options[:content_details]
+        end
         if options[:statistics]
           @statistics_set = StatisticsSet.new data: options[:statistics]
         end

--- a/lib/yt/models/content_detail.rb
+++ b/lib/yt/models/content_detail.rb
@@ -24,6 +24,7 @@ module Yt
       has_attribute :licensed_content
       has_attribute :content_rating, default: {}
       has_attribute :item_count
+      has_attribute :google_plus_user_id
 
       def youtube_rating
         content_rating['ytRating']

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -36,6 +36,8 @@ module Yt
       has_attribute :author_display_name
       has_attribute :text_display
       has_attribute :parent_id
+      has_attribute :country
+      has_attribute :custom_url
       has_attribute :like_count, type: Integer
       has_attribute :updated_at, type: Time
 


### PR DESCRIPTION
- Adds Channel attributes `country` and `custom_url` to `Snippet`.
- Adds a `ContentDetail` to `Channel` to provide access to the Google+ user ID.

Please let me know if I need to add any tests for this!
