### PR TITLE
Add videos for channel groups, as well as video groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.37  - 2016-05-16
+
+* [FEATURE] Add `VideoGroup#videos` to load all videos under a group of channels, as well as a group of videos.
 
 ## 0.25.36  - 2016-05-10
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.36'
+  VERSION = '0.25.37'
 end

--- a/spec/requests/as_content_owner/video_group_spec.rb
+++ b/spec/requests/as_content_owner/video_group_spec.rb
@@ -5,6 +5,19 @@ require 'yt/models/group_item'
 describe Yt::VideoGroup, :partner do
   subject(:video_group) { Yt::VideoGroup.new id: id, auth: $content_owner }
 
+  context 'given a channel-group', :partner do
+    context 'managed by the authenticated Content Owner' do
+      let(:id) { ENV['YT_TEST_PARTNER_CHANNEL_GROUP_ID'] }
+
+      specify '.videos loads each video of each channel' do
+        video = video_group.videos.first
+        expect(video.instance_variable_defined? :@snippet).to be true
+        expect(video.instance_variable_defined? :@status).to be true
+        expect(video.instance_variable_defined? :@statistics_set).to be true
+      end
+    end
+  end
+
   context 'given a video-group', :partner do
     context 'managed by the authenticated Content Owner' do
       let(:id) { ENV['YT_TEST_PARTNER_VIDEO_GROUP_ID'] }
@@ -29,6 +42,13 @@ describe Yt::VideoGroup, :partner do
         expect(item.video.instance_variable_defined? :@snippet).to be true
         expect(item.video.instance_variable_defined? :@status).to be true
         expect(item.video.instance_variable_defined? :@statistics_set).to be true
+      end
+
+      specify '.videos loads each video' do
+        video = video_group.videos.first
+        expect(video.instance_variable_defined? :@snippet).to be true
+        expect(video.instance_variable_defined? :@status).to be true
+        expect(video.instance_variable_defined? :@statistics_set).to be true
       end
 
       describe 'multiple reports can be retrieved at once' do


### PR DESCRIPTION
- Load all videos under a group by running `group.videos`
- Add `YT_TEST_PARTNER_CHANNEL_GROUP_ID` to test
