### PR TITLE
Don’t combine forContentOwner and publishedBefore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.38 - 2016-06-13
+
+* [IMPROVEMENT] Don’t combine forContentOwner and publishedBefore parameters in Search#list since YouTube does not support this anymore.
+
 ## 0.25.37  - 2016-05-16
 
 * [FEATURE] Add `VideoGroup#videos` to load all videos under a group of channels, as well as a group of videos.

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -96,7 +96,7 @@ module Yt
       def next_page
         super.tap do |items|
           halt_list if use_list_endpoint? && items.empty? && @page_token.nil?
-          add_offset_to(items) if !use_list_endpoint? && videos_params[:order] == 'date' && videos_params[:channel_id]
+          add_offset_to(items) if !use_list_endpoint? && videos_params[:order] == 'date' && !(videos_params[:for_mine] || videos_params[:for_content_owner])
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.37'
+  VERSION = '0.25.38'
 end


### PR DESCRIPTION
This is a new issue that was submitted to YouTube a while ago and has
not been fixed since. Combining the two parameters in the same requests
causes YouTube API to respond with a 400 error that is not documented.

To avoid this, let's just fetch all the videos from Search#list and hope
that YouTube does not return duplicates (as it used to do before).

Similar to #267 
