### PR TITLE
Specify UTF-8 to support Ruby 1.9.x

### DIFF
--- a/lib/yt/constants/geography.rb
+++ b/lib/yt/constants/geography.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'active_support'
 require 'active_support/core_ext/hash/indifferent_access'
 


### PR DESCRIPTION
On Ruby 1.9.3, the following error is thrown:

``` bash
bundler: failed to load command: yt (/ ... /.rbenv/versions/1.9.3-p125/bin/yt)
SyntaxError: /Users/greypants/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/yt-0.25.39/lib/yt/constants/geography.rb:35: invalid multibyte char (US-ASCII)
/... /.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/yt-0.25.39/lib/yt/constants/geography.rb:35: invalid multibyte char (US-ASCII)
/ ... /.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/yt-0.25.39/lib/yt/constants/geography.rb:35: syntax error, unexpected $end, expecting '}'
    BL: 'Saint Barthélemy',
                      ^
```

As of Ruby 2.0, you don't have to specify `utf-8`, but 1.9.x needs it.
