### PR TITLE
Add `attr_reader :data` to Yt::Claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.40 - 2016-09-19
+
+* [IMPROVEMENT] Add `Yt::Claim#data` to access the policy of a claim
+
 ## 0.25.39 - 2016-06-15
 
 * [FEATURE] Add `by: :operating_system` option for reports, to return views (from a `content_owner.video`) by operating system.

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -5,7 +5,7 @@ module Yt
     # Provides methods to interact with YouTube ContentID claims.
     # @see https://developers.google.com/youtube/partner/docs/v1/claims
     class Claim < Base
-      attr_reader :auth
+      attr_reader :auth, :data
 
       def initialize(options = {})
         @data = options[:data]

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.39'
+  VERSION = '0.25.40'
 end


### PR DESCRIPTION
This is useful because when we initialize a Claim, `@data` might include
a 'policy' that we might need to read to get the policy of that claim
