### PR TITLE
Update gem to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.28.0 - 2016-10-18
+
+**How to upgrade**
+
+If your code calls `.earnings` and `.impressions`
+then you must replace that code  with `.estimated_revenue` and
+`.ad_impressions` since those metrics will no longer be supported by
+YouTube API as of [November 4, 2016](https://developers.google.com/youtube/analytics/revision_history#august-10-2016).
+
+* [breaking change] Change deprecated `earnings` to `estimated_revenue`
+* [breaking change] Change deprecated `impressions` to `ad_impressions`
+
 ## 0.27.0 - 2016-10-07
 
 **How to upgrade**

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -18,7 +18,7 @@ require 'yt/models/advertising_options_set'
 # An object-oriented Ruby client for YouTube.
 # Helps creating applications that need to interact with YouTube objects.
 # Inclused methods to access YouTube Data API V3 resources (channels, videos,
-# ...), YouTube Analytics API V2 resources (metrics, earnings, ...), and
+# ...), YouTube Analytics API V2 resources (metrics, estimated_revenue, ...), and
 # objects not available through the API (annotations).
 module Yt
 end

--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -299,11 +299,11 @@ module Yt
 
       def define_all_metric_method(metric, type)
         define_method "all_#{metric}" do
-          # @note Asking for the "earnings" metric of a day in which a channel
+          # @note Asking for the "estimated_revenue" metric of a day in which a channel
           # made 0 USD returns the wrong "nil". But adding to the request the
           # "estimatedMinutesWatched" metric returns the correct value 0.
           metrics = {metric => type}
-          metrics[:estimated_minutes_watched] = Integer if metric == :earnings
+          metrics[:estimated_minutes_watched] = Integer if metric == :estimated_revenue
           Collections::Reports.of(self).tap{|reports| reports.metrics = metrics}
         end
         private "all_#{metric}"

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -136,7 +136,7 @@ module Yt
           elsif dimension.in? [:traffic_source, :country, :state, :playback_location, :device_type, :operating_system, :subscribed_status]
             hash = hash.transform_values{|h| h.sort_by{|range, v| -v}.to_h}
           end
-          (@metrics.one? || @metrics.keys == [:earnings, :estimated_minutes_watched]) ? hash[@metrics.keys.first] : hash
+          (@metrics.one? || @metrics.keys == [:estimated_revenue, :estimated_minutes_watched]) ? hash[@metrics.keys.first] : hash
         end
       # NOTE: Once in a while, YouTube responds with 400 Error and the message
       # "Invalid query. Query did not conform to the expectations."; in this
@@ -179,8 +179,8 @@ module Yt
           params['max-results'] = 50 if @dimension.in? [:playlist, :video]
           params['max-results'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
           if @dimension.in? [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer]
-            if @metrics.keys == [:earnings, :estimated_minutes_watched]
-              params['sort'] = '-earnings'
+            if @metrics.keys == [:estimated_revenue, :estimated_minutes_watched]
+              params['sort'] = '-estimatedRevenue'
             else
               params['sort'] = "-#{@metrics.keys.join(',').to_s.camelize(:lower)}"
             end

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -181,10 +181,10 @@ module Yt
       has_report :card_teaser_click_rate, Float
 
       # @macro report_by_day_and_country
-      has_report :earnings, Float
+      has_report :estimated_revenue, Float
 
       # @macro report_by_day_and_country
-      has_report :impressions, Integer
+      has_report :ad_impressions, Integer
 
       # @macro report_by_day_and_country
       has_report :monetized_playbacks, Integer

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -464,10 +464,10 @@ module Yt
       has_report :card_teaser_click_rate, Float
 
       # @macro report_by_day_and_country
-      has_report :earnings, Float
+      has_report :estimated_revenue, Float
 
       # @macro report_by_day_and_country
-      has_report :impressions, Integer
+      has_report :ad_impressions, Integer
 
       # @macro report_by_day_and_country
       has_report :monetized_playbacks, Integer

--- a/lib/yt/models/video_group.rb
+++ b/lib/yt/models/video_group.rb
@@ -90,10 +90,10 @@ module Yt
       has_report :annotation_close_rate, Float
 
       # @macro report_by_day_and_country
-      has_report :earnings, Float
+      has_report :estimated_revenue, Float
 
       # @macro report_by_day_and_country
-      has_report :impressions, Integer
+      has_report :ad_impressions, Integer
 
       # @macro report_by_day_and_country
       has_report :monetized_playbacks, Integer

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.27.0'
+  VERSION = '0.28.0'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -215,8 +215,8 @@ describe Yt::Channel, :device_app do
       expect{channel.card_teaser_clicks}.not_to raise_error
       expect{channel.card_teaser_click_rate}.not_to raise_error
       expect{channel.viewer_percentage}.not_to raise_error
-      expect{channel.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{channel.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{channel.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{channel.ad_impressions}.to raise_error Yt::Errors::Unauthorized
       expect{channel.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{channel.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
     end

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -1906,8 +1906,8 @@ describe Yt::Video, :device_app do
       expect{video.annotation_click_through_rate}.not_to raise_error
       expect{video.annotation_close_rate}.not_to raise_error
       expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -305,8 +305,1204 @@ describe Yt::Video, :device_app do
       expect{video.card_teaser_clicks}.not_to raise_error
       expect{video.card_teaser_click_rate}.not_to raise_error
       expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { '9bZkp7q19f0' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the embeddable status' do
+      let!(:old_embeddable) { video.embeddable? }
+      let!(:new_embeddable) { !old_embeddable }
+
+      let(:attrs) { {embeddable: new_embeddable} }
+
+      # @note: This test is a reflection of another irrational behavior of
+      #   YouTube API. Although 'embeddable' can be passed as an 'update'
+      #   attribute according to the documentation, it simply does not work.
+      #   The day YouTube fixes it, then this test will finally fail and will
+      #   be removed, documenting how to update 'embeddable' too.
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
+      specify 'does not update the embeddable status' do
+        expect(update).to be true
+        expect(video.embeddable?).to eq old_embeddable
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { '9bZkp7q19f0' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { '9bZkp7q19f0' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the embeddable status' do
+      let!(:old_embeddable) { video.embeddable? }
+      let!(:new_embeddable) { !old_embeddable }
+
+      let(:attrs) { {embeddable: new_embeddable} }
+
+      # @note: This test is a reflection of another irrational behavior of
+      #   YouTube API. Although 'embeddable' can be passed as an 'update'
+      #   attribute according to the documentation, it simply does not work.
+      #   The day YouTube fixes it, then this test will finally fail and will
+      #   be removed, documenting how to update 'embeddable' too.
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
+      specify 'does not update the embeddable status' do
+        expect(update).to be true
+        expect(video.embeddable?).to eq old_embeddable
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
@@ -715,1202 +1911,6 @@ describe Yt::Video, :device_app do
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { '9bZkp7q19f0' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { '9bZkp7q19f0' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { '9bZkp7q19f0' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
 
     end
   end
@@ -2312,8 +2312,8 @@ describe Yt::Video, :device_app do
       expect{video.annotation_click_through_rate}.not_to raise_error
       expect{video.annotation_close_rate}.not_to raise_error
       expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.estimated_revenue}.to raise_error Yt::Errors::Unauthorized
+      expect{video.ad_impressions}.to raise_error Yt::Errors::Unauthorized
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -129,7 +129,7 @@ describe Yt::Channel, :partner do
        average_view_percentage: Float, ad_impressions: Integer,
        shares: Integer, playback_based_cpm: Float,
        monetized_playbacks: Integer, annotation_close_rate: Float,
-       earnings: Float}.each do |metric, type|
+       estimated_revenue: Float}.each do |metric, type|
         describe "#{metric} can be grouped by range" do
           let(:metric) { metric }
 

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -22,7 +22,7 @@ describe Yt::Channel, :partner do
           card_impressions: Integer, card_clicks: Integer,
           card_click_rate: Float, card_teaser_impressions: Integer,
           card_teaser_clicks: Integer, card_teaser_click_rate: Float,
-          earnings: Float, impressions: Integer,
+          estimated_revenue: Float, ad_impressions: Integer,
           monetized_playbacks: Integer, playback_based_cpm: Float}
         specify 'by day, and are chronologically sorted' do
           range = {since: 5.days.ago.to_date, until: 3.days.ago.to_date}
@@ -63,11 +63,11 @@ describe Yt::Channel, :partner do
        :subscribers_gained, :subscribers_lost,
        :videos_added_to_playlists, :videos_removed_from_playlists,
        :estimated_minutes_watched, :average_view_duration,
-       :average_view_percentage, :impressions, :monetized_playbacks,
+       :average_view_percentage, :ad_impressions, :monetized_playbacks,
        :annotation_clicks, :annotation_click_through_rate,
        :card_impressions, :card_clicks, :card_click_rate,
        :card_teaser_impressions, :card_teaser_clicks, :card_teaser_click_rate,
-       :playback_based_cpm, :annotation_close_rate, :earnings].each do |metric|
+       :playback_based_cpm, :annotation_close_rate, :estimated_revenue].each do |metric|
         describe "#{metric} can be retrieved for a range of days" do
           let(:date_in) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
           let(:date_out) { Date.parse(ENV['YT_TEST_PARTNER_VIDEO_DATE']) + 5 }
@@ -126,7 +126,7 @@ describe Yt::Channel, :partner do
        card_click_rate: Float, card_teaser_impressions: Integer,
        card_teaser_clicks: Integer, card_teaser_click_rate: Float,
        videos_added_to_playlists: Integer, videos_removed_from_playlists: Integer,
-       average_view_percentage: Float, impressions: Integer,
+       average_view_percentage: Float, ad_impressions: Integer,
        shares: Integer, playback_based_cpm: Float,
        monetized_playbacks: Integer, annotation_close_rate: Float,
        earnings: Float}.each do |metric, type|
@@ -151,24 +151,24 @@ describe Yt::Channel, :partner do
         end
       end
 
-      describe 'earnings can be retrieved for a specific day' do
+      describe 'estimated_revenue can be retrieved for a specific day' do
         # NOTE: This test sounds redundant, but it’s actually a reflection of
         # another irrational behavior of YouTube API. In short, if you ask for
-        # the "earnings" metric of a day in which a channel made 0 USD, then
-        # the API returns "nil". But if you also for the "earnings" metric AND
+        # the "estimated_revenue" metric of a day in which a channel made 0 USD, then
+        # the API returns "nil". But if you also for the "estimated_revenue" metric AND
         # the "estimatedMinutesWatched" metric, then the API returns the
         # correct value of "0", while still returning nil for those days in
-        # which the earnings have not been estimated yet.
+        # which the estimated_revenue have not been estimated yet.
         context 'in which the channel did not make any money' do
-          let(:zero_date) { ENV['YT_TEST_PARTNER_CHANNEL_NO_EARNINGS_DATE'] }
-          let(:earnings) { channel.earnings_on zero_date}
-          it { expect(earnings).to eq 0 }
+          let(:zero_date) { ENV['YT_TEST_PARTNER_CHANNEL_NO_estimated_revenue_DATE'] }
+          let(:estimated_revenue) { channel.estimated_revenue_on zero_date}
+          it { expect(estimated_revenue).to eq 0 }
         end
       end
 
-      describe 'earnings can be retrieved for a single country' do
+      describe 'estimated_revenue can be retrieved for a single country' do
         let(:country_code) { 'US' }
-        let(:earnings) { channel.earnings since: date, by: by, in: location }
+        let(:estimated_revenue) { channel.estimated_revenue since: date, by: by, in: location }
         let(:date) { 4.days.ago }
 
         context 'and grouped by day' do
@@ -176,12 +176,12 @@ describe Yt::Channel, :partner do
 
           context 'with the :in option set to the country code' do
             let(:location) { country_code }
-            it { expect(earnings.keys.min).to eq date.to_date }
+            it { expect(estimated_revenue.keys.min).to eq date.to_date }
           end
 
           context 'with the :in option set to {country: country code}' do
             let(:location) { {country: country_code} }
-            it { expect(earnings.keys.min).to eq date.to_date }
+            it { expect(estimated_revenue.keys.min).to eq date.to_date }
           end
         end
 
@@ -190,34 +190,34 @@ describe Yt::Channel, :partner do
 
           context 'with the :in option set to the country code' do
             let(:location) { country_code }
-            it { expect(earnings.keys).to eq [country_code] }
+            it { expect(estimated_revenue.keys).to eq [country_code] }
           end
 
           context 'with the :in option set to {country: country code}' do
             let(:location) { {country: country_code} }
-            it { expect(earnings.keys).to eq [country_code] }
+            it { expect(estimated_revenue.keys).to eq [country_code] }
           end
         end
       end
 
-      describe 'earnings can be grouped by day' do
+      describe 'estimated_revenue can be grouped by day' do
         let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
         let(:keys) { range.values }
 
         specify 'with the :by option set to :day' do
-          earnings = channel.earnings range.merge by: :day
-          expect(earnings.keys).to eq range.values
+          estimated_revenue = channel.estimated_revenue range.merge by: :day
+          expect(estimated_revenue.keys).to eq range.values
         end
       end
 
-      describe 'earnings can be grouped by country' do
+      describe 'estimated_revenue can be grouped by country' do
         let(:range) { {since: 4.days.ago, until: 3.days.ago} }
 
         specify 'with the :by option set to :country' do
-          earnings = channel.earnings range.merge by: :country
-          expect(earnings.keys).to all(be_a String)
-          expect(earnings.keys.map(&:length).uniq).to eq [2]
-          expect(earnings.values).to all(be_a Float)
+          estimated_revenue = channel.estimated_revenue range.merge by: :country
+          expect(estimated_revenue.keys).to all(be_a String)
+          expect(estimated_revenue.keys.map(&:length).uniq).to eq [2]
+          expect(estimated_revenue.values).to all(be_a Float)
         end
       end
 
@@ -1319,9 +1319,9 @@ describe Yt::Channel, :partner do
         end
       end
 
-      describe 'impressions can be retrieved for a single country' do
+      describe 'ad_impressions can be retrieved for a single country' do
         let(:country_code) { 'US' }
-        let(:impressions) { channel.impressions since: date, by: by, in: location }
+        let(:ad_impressions) { channel.ad_impressions since: date, by: by, in: location }
         let(:date) { ENV['YT_TEST_PARTNER_PLAYLIST_DATE'] }
 
         context 'and grouped by day' do
@@ -1329,12 +1329,12 @@ describe Yt::Channel, :partner do
 
           context 'with the :in option set to the country code' do
             let(:location) { country_code }
-            it { expect(impressions.keys.min).to eq date.to_date }
+            it { expect(ad_impressions.keys.min).to eq date.to_date }
           end
 
           context 'with the :in option set to {country: country code}' do
             let(:location) { {country: country_code} }
-            it { expect(impressions.keys.min).to eq date.to_date }
+            it { expect(ad_impressions.keys.min).to eq date.to_date }
           end
         end
 
@@ -1343,34 +1343,34 @@ describe Yt::Channel, :partner do
 
           context 'with the :in option set to the country code' do
             let(:location) { country_code }
-            it { expect(impressions.keys).to eq [country_code] }
+            it { expect(ad_impressions.keys).to eq [country_code] }
           end
 
           context 'with the :in option set to {country: country code}' do
             let(:location) { {country: country_code} }
-            it { expect(impressions.keys).to eq [country_code] }
+            it { expect(ad_impressions.keys).to eq [country_code] }
           end
         end
       end
 
-      describe 'impressions can be grouped by day' do
+      describe 'ad_impressions can be grouped by day' do
         let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
         let(:keys) { range.values }
 
         specify 'with the :by option set to :day' do
-          impressions = channel.impressions range.merge by: :day
-          expect(impressions.keys).to eq range.values
+          ad_impressions = channel.ad_impressions range.merge by: :day
+          expect(ad_impressions.keys).to eq range.values
         end
       end
 
-      describe 'impressions can be grouped by country' do
+      describe 'ad_impressions can be grouped by country' do
         let(:range) { {since: ENV['YT_TEST_PARTNER_PLAYLIST_DATE']} }
 
         specify 'with the :by option set to :country' do
-          impressions = channel.impressions range.merge by: :country
-          expect(impressions.keys).to all(be_a String)
-          expect(impressions.keys.map(&:length).uniq).to eq [2]
-          expect(impressions.values).to all(be_an Integer)
+          ad_impressions = channel.ad_impressions range.merge by: :country
+          expect(ad_impressions.keys).to all(be_a String)
+          expect(ad_impressions.keys.map(&:length).uniq).to eq [2]
+          expect(ad_impressions.values).to all(be_an Integer)
         end
       end
 
@@ -1872,8 +1872,8 @@ describe Yt::Channel, :partner do
     context 'not managed by the authenticated Content Owner' do
       let(:id) { 'UCBR8-60-B28hp2BmDPdntcQ' }
 
-      specify 'earnings and impressions cannot be retrieved' do
-        expect{channel.earnings}.to raise_error Yt::Errors::Forbidden
+      specify 'estimated_revenue and ad_impressions cannot be retrieved' do
+        expect{channel.estimated_revenue}.to raise_error Yt::Errors::Forbidden
         expect{channel.views}.to raise_error Yt::Errors::Forbidden
       end
 

--- a/spec/requests/as_content_owner/video_group_spec.rb
+++ b/spec/requests/as_content_owner/video_group_spec.rb
@@ -60,7 +60,7 @@ describe Yt::VideoGroup, :partner do
           average_view_duration: Integer,
           average_view_percentage: Float, annotation_clicks: Integer,
           annotation_click_through_rate: Float,
-          annotation_close_rate: Float, earnings: Float, impressions: Integer,
+          annotation_close_rate: Float, estimated_revenue: Float, ad_impressions: Integer,
           monetized_playbacks: Integer}
 
         specify 'by day, and are chronologically sorted' do

--- a/spec/requests/as_content_owner/video_spec.rb
+++ b/spec/requests/as_content_owner/video_spec.rb
@@ -17,11 +17,11 @@ describe Yt::Video, :partner do
        :subscribers_gained, :subscribers_lost,
        :videos_added_to_playlists, :videos_removed_from_playlists,
        :estimated_minutes_watched, :average_view_duration,
-       :average_view_percentage, :impressions, :monetized_playbacks,
+       :average_view_percentage, :ad_impressions, :monetized_playbacks,
        :annotation_clicks, :annotation_click_through_rate, :playback_based_cpm,
        :card_impressions, :card_clicks, :card_click_rate,
        :card_teaser_impressions, :card_teaser_clicks, :card_teaser_click_rate,
-       :annotation_close_rate, :earnings].each do |metric|
+       :annotation_close_rate, :estimated_revenue].each do |metric|
         describe "#{metric} can be retrieved for a range of days" do
           let(:date_in) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
           let(:date_out) { Date.parse(ENV['YT_TEST_PARTNER_VIDEO_DATE']) + 5 }
@@ -94,13 +94,13 @@ describe Yt::Video, :partner do
        shares: Integer, subscribers_gained: Integer, subscribers_lost: Integer,
        videos_added_to_playlists: Integer, videos_removed_from_playlists: Integer,
        estimated_minutes_watched: Integer, average_view_duration: Integer,
-       average_view_percentage: Float, impressions: Integer,
+       average_view_percentage: Float, ad_impressions: Integer,
        monetized_playbacks: Integer, annotation_clicks: Integer,
        annotation_click_through_rate: Float, annotation_close_rate: Float,
        card_impressions: Integer, card_clicks: Integer,
        card_click_rate: Float, card_teaser_impressions: Integer,
        card_teaser_clicks: Integer, card_teaser_click_rate: Float,
-       earnings: Float}.each do |metric, type|
+       estimated_revenue: Float}.each do |metric, type|
         describe "#{metric} can be grouped by range" do
           let(:metric) { metric }
 
@@ -126,11 +126,11 @@ describe Yt::Video, :partner do
        :subscribers_gained, :subscribers_lost,
        :videos_added_to_playlists, :videos_removed_from_playlists,
        :estimated_minutes_watched, :average_view_duration,
-       :average_view_percentage, :impressions, :monetized_playbacks,
+       :average_view_percentage, :ad_impressions, :monetized_playbacks,
        :card_impressions, :card_clicks, :card_click_rate,
        :card_teaser_impressions, :card_teaser_clicks, :card_teaser_click_rate,
        :annotation_clicks, :annotation_click_through_rate,
-       :annotation_close_rate, :earnings].each do |metric|
+       :annotation_close_rate, :estimated_revenue].each do |metric|
         describe "#{metric} can be retrieved for a single country" do
           let(:result) { video.public_send metric, options }
 
@@ -185,7 +185,7 @@ describe Yt::Video, :partner do
           card_click_rate: Float, card_teaser_impressions: Integer,
           card_teaser_clicks: Integer, card_teaser_click_rate: Float,
           annotation_click_through_rate: Float,
-          annotation_close_rate: Float, earnings: Float, impressions: Integer,
+          annotation_close_rate: Float, estimated_revenue: Float, ad_impressions: Integer,
           monetized_playbacks: Integer}
 
         specify 'by day' do
@@ -222,24 +222,24 @@ describe Yt::Video, :partner do
         end
       end
 
-      describe 'earnings can be grouped by day' do
+      describe 'estimated_revenue can be grouped by day' do
         let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
         let(:keys) { range.values }
 
         specify 'with the :by option set to :day' do
-          earnings = video.earnings range.merge by: :day
-          expect(earnings.keys).to eq range.values
+          estimated_revenue = video.estimated_revenue range.merge by: :day
+          expect(estimated_revenue.keys).to eq range.values
         end
       end
 
-      describe 'earnings can be grouped by country' do
+      describe 'estimated_revenue can be grouped by country' do
         let(:range) { {since: 4.days.ago, until: 3.days.ago} }
 
         specify 'with the :by option set to :country' do
-          earnings = video.earnings range.merge by: :country
-          expect(earnings.keys).to all(be_a String)
-          expect(earnings.keys.map(&:length).uniq).to eq [2]
-          expect(earnings.values).to all(be_a Float)
+          estimated_revenue = video.estimated_revenue range.merge by: :country
+          expect(estimated_revenue.keys).to all(be_a String)
+          expect(estimated_revenue.keys.map(&:length).uniq).to eq [2]
+          expect(estimated_revenue.values).to all(be_a Float)
         end
       end
 
@@ -874,24 +874,24 @@ describe Yt::Video, :partner do
         end
       end
 
-      describe 'impressions can be grouped by day' do
+      describe 'ad_impressions can be grouped by day' do
         let(:range) { {since: 4.days.ago.to_date, until: 3.days.ago.to_date} }
         let(:keys) { range.values }
 
         specify 'with the :by option set to :day' do
-          impressions = video.impressions range.merge by: :day
-          expect(impressions.keys).to eq range.values
+          ad_impressions = video.ad_impressions range.merge by: :day
+          expect(ad_impressions.keys).to eq range.values
         end
       end
 
-      describe 'impressions can be grouped by country' do
+      describe 'ad_impressions can be grouped by country' do
         let(:range) { {since: ENV['YT_TEST_PARTNER_VIDEO_DATE']} }
 
         specify 'with the :by option set to :country' do
-          impressions = video.impressions range.merge by: :country
-          expect(impressions.keys).to all(be_a String)
-          expect(impressions.keys.map(&:length).uniq).to eq [2]
-          expect(impressions.values).to all(be_an Integer)
+          ad_impressions = video.ad_impressions range.merge by: :country
+          expect(ad_impressions.keys).to all(be_a String)
+          expect(ad_impressions.keys.map(&:length).uniq).to eq [2]
+          expect(ad_impressions.values).to all(be_an Integer)
         end
       end
 


### PR DESCRIPTION
- Change earnings & impressions to estimated_revenue and ad_impressions
- source:
  https://developers.google.com/youtube/analytics/revision_history#august-10-2016
