### PR TITLE
Remove `_on` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,7 +644,7 @@ error by using the `unsubscribe` method:
 
 ## 0.11.5 - 2014-08-27
 
-* [BUGFIX] Make videos.where(id: 'MESycYJytkU').first.id return 'MESycYJytkU'
+* [BUGFIX] Make videos.where(id: 'jNQXAC9IVRw').first.id return 'jNQXAC9IVRw'
 
 ## 0.11.4 - 2014-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.27.0 - 2016-10-07
+
+**How to upgrade**
+
+If your code calls any of the following `..._on` method to fetch metrics on
+a specific day, you need to replace it with the equivalent method that does
+not end with `_on`. For instance replace `views_on(3.days.ago)` with the
+equivalent `views(since: 3.days.ago, until: 3.days.ago)`.
+
+* [REMOVAL] Remove `#views_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#uniques_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#estimated_minutes_watched_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#viewer_percentage_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#comments_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#likes_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#dislikes_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#shares_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#subscribers_gained_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#subscribers_lost_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#videos_added_to_playlists_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#videos_removed_from_playlists_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#average_view_duration_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#average_view_percentage_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#annotation_clicks_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#annotation_click_through_rate_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#annotation_close_rate_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_impressions_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_clicks_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_click_rate_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_teaser_impressions_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_teaser_clicks_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#card_teaser_click_rate_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#earnings_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#impressions_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#monetized_playbacks_on` method for channels, playlists, videos and video groups
+* [REMOVAL] Remove `#playback_based_cpm_on` method for channels, playlists, videos and video groups
+
 ## 0.26.3 - 2016-10-07
 
 * [FEATURE] Add `by: :subscribed_status` option for reports, to return views (from a `content_owner.video`) by subscribed status.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ channel.videos.count #=> 12
 ```
 
 ```ruby
-video = Yt::Video.new id: 'MESycYJytkU'
+video = Yt::Video.new id: 'jNQXAC9IVRw'
 video.title #=> "Fullscreen Creator Platform"
 video.comment_count #=> 308
 video.hd? #=> true
@@ -83,7 +83,7 @@ content_owner.partnered_channels.where(part: 'statistics').map &:subscriber_coun
 
 content_owner.claims.where(q: 'Fullscreen').count #=> 24
 content_owner.claims.first #=> #<Yt::Models::Claim @id=...>
-content_owner.claims.first.video_id #=> 'MESycYJytkU'
+content_owner.claims.first.video_id #=> 'jNQXAC9IVRw'
 content_owner.claims.first.status #=> "active"
 
 reference = content_owner.references.where(asset_id: "ABCDEFG").first #=> #<Yt::Models::Reference @id=...>
@@ -178,7 +178,7 @@ videos = Yt::Collections::Videos.new
 videos.where(order: 'viewCount').first.title #=>  "PSY - GANGNAM STYLE"
 videos.where(q: 'Fullscreen CreatorPlatform', safe_search: 'none').size #=> 324
 videos.where(chart: 'mostPopular', video_category_id: 44).first.title #=> "SINISTER - Trailer"
-videos.where(id: 'MESycYJytkU,invalid').map(&:title) #=> ["Fullscreen Creator Platform"]
+videos.where(id: 'jNQXAC9IVRw,invalid').map(&:title) #=> ["Fullscreen Creator Platform"]
 ```
 
 *The methods above do not require authentication.*
@@ -293,7 +293,7 @@ Use [Yt::AdvertisingOptionsSet](http://www.rubydoc.info/gems/yt/Yt/Models/Advert
 
 ```ruby
 content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.1.ABCDEFGHIJ'
-ad_options = Yt::AdvertisingOptionsSet.new video_id: 'MESycYJytkU', auth: $content_owner
+ad_options = Yt::AdvertisingOptionsSet.new video_id: 'jNQXAC9IVRw', auth: $content_owner
 ad_options.update ad_formats: %w(standard_instream long) #=> true
 ```
 

--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -206,18 +206,17 @@ module Yt
       #   @macro report
       #   @macro report_with_country_and_state
 
-      # Defines two public instance methods to access the reports of a
+      # Defines a public instance methods to access the reports of a
       # resource for a specific metric.
       # @param [Symbol] metric the metric to access the reports of.
       # @param [Class] type The class to cast the returned values to.
-      # @example Adds +comments+ and +comments_on+ on a Channel resource.
+      # @example Adds +comments+ on a Channel resource.
       #   class Channel < Resource
       #     has_report :comments, Integer
       #   end
       def has_report(metric, type)
         require 'yt/collections/reports'
 
-        define_metric_on_method metric
         define_metric_method metric
         define_reports_method metric, type
         define_range_metric_method metric
@@ -225,12 +224,6 @@ module Yt
       end
 
     private
-
-      def define_metric_on_method(metric)
-        define_method "#{metric}_on" do |date|
-          send(metric, from: date, to: date, by: :day).values.first
-        end
-      end
 
       def define_reports_method(metric, type)
         (@metrics ||= {})[metric] = type

--- a/lib/yt/models/description.rb
+++ b/lib/yt/models/description.rb
@@ -10,7 +10,7 @@ module Yt
     class Description < String
       # @return [Boolean] whether the description includes a link to a video
       # @example
-      #   description = Yt::Models::Description.new 'Link to video: youtube.com/watch?v=jNQXAC9IVRw'
+      #   description = Yt::Models::Description.new 'Link to video: youtube.com/watch?v=9bZkp7q19f0'
       #   description.has_link_to_video? #=> true
       #
       # @todo add an option to match the link to a specific video

--- a/lib/yt/models/description.rb
+++ b/lib/yt/models/description.rb
@@ -10,7 +10,7 @@ module Yt
     class Description < String
       # @return [Boolean] whether the description includes a link to a video
       # @example
-      #   description = Yt::Models::Description.new 'Link to video: youtube.com/watch?v=MESycYJytkU'
+      #   description = Yt::Models::Description.new 'Link to video: youtube.com/watch?v=jNQXAC9IVRw'
       #   description.has_link_to_video? #=> true
       #
       # @todo add an option to match the link to a specific video

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.26.3'
+  VERSION = '0.27.0'
 end

--- a/spec/collections/playlist_items_spec.rb
+++ b/spec/collections/playlist_items_spec.rb
@@ -6,7 +6,7 @@ require 'yt/collections/playlist_items'
 describe Yt::Collections::PlaylistItems do
   subject(:collection) { Yt::Collections::PlaylistItems.new parent: playlist }
   let(:playlist) { Yt::Playlist.new id: 'LLxO1tY8h1AhOz0T4ENwmpow' }
-  let(:attrs) { {id: 'jNQXAC9IVRw', kind: :video} }
+  let(:attrs) { {id: '9bZkp7q19f0', kind: :video} }
   let(:msg) { {response_body: {error: {errors: [{reason: reason}]}}}.to_json }
   before { expect(collection).to behave }
 

--- a/spec/collections/playlist_items_spec.rb
+++ b/spec/collections/playlist_items_spec.rb
@@ -6,7 +6,7 @@ require 'yt/collections/playlist_items'
 describe Yt::Collections::PlaylistItems do
   subject(:collection) { Yt::Collections::PlaylistItems.new parent: playlist }
   let(:playlist) { Yt::Playlist.new id: 'LLxO1tY8h1AhOz0T4ENwmpow' }
-  let(:attrs) { {id: 'MESycYJytkU', kind: :video} }
+  let(:attrs) { {id: 'jNQXAC9IVRw', kind: :video} }
   let(:msg) { {response_body: {error: {errors: [{reason: reason}]}}}.to_json }
   before { expect(collection).to behave }
 

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -86,7 +86,7 @@ describe Yt::Annotation do
     end
 
     context 'given an annotation with an embedded playlist link' do
-      let(:xml) { '<TEXT>https://www.youtube.com/watch?v=jNQXAC9IVRw&amp;list=LLxO1tY8h1AhOz0T4ENwmpow"</TEXT>' }
+      let(:xml) { '<TEXT>https://www.youtube.com/watch?v=9bZkp7q19f0&amp;list=LLxO1tY8h1AhOz0T4ENwmpow"</TEXT>' }
       it { expect(annotation).to have_link_to_playlist }
     end
 

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -86,7 +86,7 @@ describe Yt::Annotation do
     end
 
     context 'given an annotation with an embedded playlist link' do
-      let(:xml) { '<TEXT>https://www.youtube.com/watch?v=MESycYJytkU&amp;list=LLxO1tY8h1AhOz0T4ENwmpow"</TEXT>' }
+      let(:xml) { '<TEXT>https://www.youtube.com/watch?v=jNQXAC9IVRw&amp;list=LLxO1tY8h1AhOz0T4ENwmpow"</TEXT>' }
       it { expect(annotation).to have_link_to_playlist }
     end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -20,8 +20,8 @@ describe Yt::Claim do
 
   describe '#video_id' do
     context 'given fetching a claim returns an videoId' do
-      let(:data) { {"videoId"=>"MESycYJytkU"} }
-      it { expect(claim.video_id).to eq 'MESycYJytkU' }
+      let(:data) { {"videoId"=>"jNQXAC9IVRw"} }
+      it { expect(claim.video_id).to eq 'jNQXAC9IVRw' }
     end
   end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -20,8 +20,8 @@ describe Yt::Claim do
 
   describe '#video_id' do
     context 'given fetching a claim returns an videoId' do
-      let(:data) { {"videoId"=>"jNQXAC9IVRw"} }
-      it { expect(claim.video_id).to eq 'jNQXAC9IVRw' }
+      let(:data) { {"videoId"=>"9bZkp7q19f0"} }
+      it { expect(claim.video_id).to eq '9bZkp7q19f0' }
     end
   end
 

--- a/spec/models/description_spec.rb
+++ b/spec/models/description_spec.rb
@@ -21,24 +21,24 @@ describe Yt::Description do
     end
 
     context 'with a video long URL' do
-      let(:text) { 'example.com and Link to video: youtube.com/watch?v=jNQXAC9IVRw' }
+      let(:text) { 'example.com and Link to video: youtube.com/watch?v=9bZkp7q19f0' }
       it { expect(description).to have_link_to_video }
     end
 
     context 'with a video short URL' do
-      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
+      let(:text) { 'Link to video: youtu.be/9bZkp7q19f0' }
       it { expect(description).to have_link_to_video }
     end
 
     context 'with a playlist-embedded video URL' do
-      let(:text) { 'Link to video in playlist: youtube.com/watch?v=jNQXAC9IVRw&index=619&list=LLxO1tY8h1AhOz0T4ENwmpow' }
+      let(:text) { 'Link to video in playlist: youtube.com/watch?v=9bZkp7q19f0&index=619&list=LLxO1tY8h1AhOz0T4ENwmpow' }
       it { expect(description).to have_link_to_video }
     end
   end
 
   describe '#has_link_to_channel?' do
     context 'without a channel URL' do
-      let(:text) { 'youtu.be/jNQXAC9IVRw is a video link' }
+      let(:text) { 'youtu.be/9bZkp7q19f0 is a video link' }
       it { expect(description).not_to have_link_to_channel }
     end
 
@@ -60,7 +60,7 @@ describe Yt::Description do
 
   describe '#has_link_to_subscribe?' do
     context 'without a subscribe URL' do
-      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
+      let(:text) { 'Link to video: youtu.be/9bZkp7q19f0' }
       it { expect(description).not_to have_link_to_subscribe }
     end
 
@@ -82,7 +82,7 @@ describe Yt::Description do
 
   describe '#has_link_to_playlist?' do
     context 'without a playlist URL' do
-      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
+      let(:text) { 'Link to video: youtu.be/9bZkp7q19f0' }
       it { expect(description).not_to have_link_to_playlist }
     end
 

--- a/spec/models/description_spec.rb
+++ b/spec/models/description_spec.rb
@@ -21,24 +21,24 @@ describe Yt::Description do
     end
 
     context 'with a video long URL' do
-      let(:text) { 'example.com and Link to video: youtube.com/watch?v=MESycYJytkU' }
+      let(:text) { 'example.com and Link to video: youtube.com/watch?v=jNQXAC9IVRw' }
       it { expect(description).to have_link_to_video }
     end
 
     context 'with a video short URL' do
-      let(:text) { 'Link to video: youtu.be/MESycYJytkU' }
+      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
       it { expect(description).to have_link_to_video }
     end
 
     context 'with a playlist-embedded video URL' do
-      let(:text) { 'Link to video in playlist: youtube.com/watch?v=MESycYJytkU&index=619&list=LLxO1tY8h1AhOz0T4ENwmpow' }
+      let(:text) { 'Link to video in playlist: youtube.com/watch?v=jNQXAC9IVRw&index=619&list=LLxO1tY8h1AhOz0T4ENwmpow' }
       it { expect(description).to have_link_to_video }
     end
   end
 
   describe '#has_link_to_channel?' do
     context 'without a channel URL' do
-      let(:text) { 'youtu.be/MESycYJytkU is a video link' }
+      let(:text) { 'youtu.be/jNQXAC9IVRw is a video link' }
       it { expect(description).not_to have_link_to_channel }
     end
 
@@ -60,7 +60,7 @@ describe Yt::Description do
 
   describe '#has_link_to_subscribe?' do
     context 'without a subscribe URL' do
-      let(:text) { 'Link to video: youtu.be/MESycYJytkU' }
+      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
       it { expect(description).not_to have_link_to_subscribe }
     end
 
@@ -82,7 +82,7 @@ describe Yt::Description do
 
   describe '#has_link_to_playlist?' do
     context 'without a playlist URL' do
-      let(:text) { 'Link to video: youtu.be/MESycYJytkU' }
+      let(:text) { 'Link to video: youtu.be/jNQXAC9IVRw' }
       it { expect(description).not_to have_link_to_playlist }
     end
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -156,8 +156,8 @@ describe Yt::Reference do
 
   describe '#video_id' do
     context 'given fetching a reference returns an videoId' do
-      let(:data) { {"videoId"=>"MESycYJytkU"} }
-      it { expect(reference.video_id).to eq 'MESycYJytkU' }
+      let(:data) { {"videoId"=>"jNQXAC9IVRw"} }
+      it { expect(reference.video_id).to eq 'jNQXAC9IVRw' }
     end
   end
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -156,8 +156,8 @@ describe Yt::Reference do
 
   describe '#video_id' do
     context 'given fetching a reference returns an videoId' do
-      let(:data) { {"videoId"=>"jNQXAC9IVRw"} }
-      it { expect(reference.video_id).to eq 'jNQXAC9IVRw' }
+      let(:data) { {"videoId"=>"9bZkp7q19f0"} }
+      it { expect(reference.video_id).to eq '9bZkp7q19f0' }
     end
   end
 

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -5,9 +5,9 @@ describe Yt::Resource do
   subject(:resource) { Yt::Resource.new attrs }
 
   context 'given a resource initialized with a URL (containing an ID)' do
-    let(:attrs) { {url: 'youtu.be/MESycYJytkU'} }
+    let(:attrs) { {url: 'youtu.be/jNQXAC9IVRw'} }
 
-    it { expect(resource.id).to eq 'MESycYJytkU' }
+    it { expect(resource.id).to eq 'jNQXAC9IVRw' }
     it { expect(resource.kind).to eq 'video' }
     it { expect(resource.username).to be_nil }
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -5,9 +5,9 @@ describe Yt::Resource do
   subject(:resource) { Yt::Resource.new attrs }
 
   context 'given a resource initialized with a URL (containing an ID)' do
-    let(:attrs) { {url: 'youtu.be/jNQXAC9IVRw'} }
+    let(:attrs) { {url: 'youtu.be/9bZkp7q19f0'} }
 
-    it { expect(resource.id).to eq 'jNQXAC9IVRw' }
+    it { expect(resource.id).to eq '9bZkp7q19f0' }
     it { expect(resource.kind).to eq 'video' }
     it { expect(resource.username).to be_nil }
   end

--- a/spec/models/url_spec.rb
+++ b/spec/models/url_spec.rb
@@ -7,34 +7,34 @@ describe Yt::URL do
   subject(:url) { Yt::URL.new text }
 
   context 'given a long video URL' do
-    let(:text) { 'youtube.com/watch?v=MESycYJytkU' }
+    let(:text) { 'youtube.com/watch?v=jNQXAC9IVRw' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'MESycYJytkU' }
+    it {expect(url.id).to eq 'jNQXAC9IVRw' }
     it {expect(url.username).to be_nil }
   end
 
   context 'given a short video URL' do
-    let(:text) { 'https://youtu.be/MESycYJytkU' }
+    let(:text) { 'https://youtu.be/jNQXAC9IVRw' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'MESycYJytkU' }
+    it {expect(url.id).to eq 'jNQXAC9IVRw' }
   end
 
   context 'given an embed video URL' do
-    let(:text) { 'https://www.youtube.com/embed/MESycYJytkU' }
+    let(:text) { 'https://www.youtube.com/embed/jNQXAC9IVRw' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'MESycYJytkU' }
+    it {expect(url.id).to eq 'jNQXAC9IVRw' }
   end
 
   context 'given a v video URL' do
-    let(:text) { 'https://www.youtube.com/v/MESycYJytkU' }
+    let(:text) { 'https://www.youtube.com/v/jNQXAC9IVRw' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'MESycYJytkU' }
+    it {expect(url.id).to eq 'jNQXAC9IVRw' }
   end
 
   context 'given a playlist-embedded video URL' do
-    let(:text) { 'youtube.com/watch?v=MESycYJytkU&list=LLxO1tY8h1AhOz0T4ENwmpow' }
+    let(:text) { 'youtube.com/watch?v=jNQXAC9IVRw&list=LLxO1tY8h1AhOz0T4ENwmpow' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'MESycYJytkU' }
+    it {expect(url.id).to eq 'jNQXAC9IVRw' }
   end
 
   context 'given a long channel URL' do

--- a/spec/models/url_spec.rb
+++ b/spec/models/url_spec.rb
@@ -7,34 +7,34 @@ describe Yt::URL do
   subject(:url) { Yt::URL.new text }
 
   context 'given a long video URL' do
-    let(:text) { 'youtube.com/watch?v=jNQXAC9IVRw' }
+    let(:text) { 'youtube.com/watch?v=9bZkp7q19f0' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'jNQXAC9IVRw' }
+    it {expect(url.id).to eq '9bZkp7q19f0' }
     it {expect(url.username).to be_nil }
   end
 
   context 'given a short video URL' do
-    let(:text) { 'https://youtu.be/jNQXAC9IVRw' }
+    let(:text) { 'https://youtu.be/9bZkp7q19f0' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'jNQXAC9IVRw' }
+    it {expect(url.id).to eq '9bZkp7q19f0' }
   end
 
   context 'given an embed video URL' do
-    let(:text) { 'https://www.youtube.com/embed/jNQXAC9IVRw' }
+    let(:text) { 'https://www.youtube.com/embed/9bZkp7q19f0' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'jNQXAC9IVRw' }
+    it {expect(url.id).to eq '9bZkp7q19f0' }
   end
 
   context 'given a v video URL' do
-    let(:text) { 'https://www.youtube.com/v/jNQXAC9IVRw' }
+    let(:text) { 'https://www.youtube.com/v/9bZkp7q19f0' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'jNQXAC9IVRw' }
+    it {expect(url.id).to eq '9bZkp7q19f0' }
   end
 
   context 'given a playlist-embedded video URL' do
-    let(:text) { 'youtube.com/watch?v=jNQXAC9IVRw&list=LLxO1tY8h1AhOz0T4ENwmpow' }
+    let(:text) { 'youtube.com/watch?v=9bZkp7q19f0&list=LLxO1tY8h1AhOz0T4ENwmpow' }
     it {expect(url.kind).to eq :video }
-    it {expect(url.id).to eq 'jNQXAC9IVRw' }
+    it {expect(url.id).to eq '9bZkp7q19f0' }
   end
 
   context 'given a long channel URL' do

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -649,7 +649,7 @@ describe Yt::Video do
   end
 
   describe '#update' do
-    let(:attrs) { {id: 'jNQXAC9IVRw', snippet: {'title'=>'old'}} }
+    let(:attrs) { {id: '9bZkp7q19f0', snippet: {'title'=>'old'}} }
     before { expect(video).to receive(:do_update).and_yield 'snippet'=>{'title'=>'new'} }
 
     it { expect(video.update title: 'new').to be true }

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -649,7 +649,7 @@ describe Yt::Video do
   end
 
   describe '#update' do
-    let(:attrs) { {id: 'MESycYJytkU', snippet: {'title'=>'old'}} }
+    let(:attrs) { {id: 'jNQXAC9IVRw', snippet: {'title'=>'old'}} }
     before { expect(video).to receive(:do_update).and_yield 'snippet'=>{'title'=>'new'} }
 
     it { expect(video.update title: 'new').to be true }

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -27,10 +27,7 @@ describe Yt::Account, :device_app do
       expect(uploads).not_to be_empty
     end
 
-    specify 'includes private playlists (such as Watch Later or History)' do
-      watch_later = related_playlists.select{|p| p.title == 'Watch Later'}
-      expect(watch_later).not_to be_empty
-
+    specify 'includes private playlists (such as History)' do
       history = related_playlists.select{|p| p.title == 'History'}
       expect(history).not_to be_empty
     end

--- a/spec/requests/as_account/authentications_spec.rb
+++ b/spec/requests/as_account/authentications_spec.rb
@@ -41,7 +41,7 @@ describe Yt::Account, :device_app do
       end
 
       context 'that is invalid' do
-        let(:authorization_code) { '--not-a-valid-authorization-code--' }
+        let(:authorization_code) { rand(36**20).to_s(36) }
         it { expect{account.authentication}.to raise_error Yt::Errors::Unauthorized }
       end
     end
@@ -104,18 +104,6 @@ describe Yt::Account, :device_app do
 
         it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
       end
-
-      context 'and no device token' do
-        it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
-      end
-
-      # NOTE: This test is commented out because of YouTube irrational behavior
-      # of using to return "MissingAuth" when passing a wrong device code, and
-      # now randomly returning `{"error"=>"internal_failure"}` instead.
-      # context 'and an invalid device code' do
-      #   before { attrs[:device_code] = '--not-a-valid-device-code--' }
-      #   it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
-      # end
     end
 
     context 'given no token or code' do

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -232,21 +232,6 @@ describe Yt::Channel, :device_app do
       expect{channel.impressions}.to raise_error Yt::Errors::Unauthorized
       expect{channel.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{channel.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-
-      expect{channel.views_on 3.days.ago}.not_to raise_error
-      expect{channel.comments_on 3.days.ago}.not_to raise_error
-      expect{channel.likes_on 3.days.ago}.not_to raise_error
-      expect{channel.dislikes_on 3.days.ago}.not_to raise_error
-      expect{channel.shares_on 3.days.ago}.not_to raise_error
-      expect{channel.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{channel.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{channel.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{channel.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{channel.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{channel.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{channel.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{channel.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{channel.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
     end
 
     it 'cannot give information about its content owner' do

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -80,23 +80,6 @@ describe Yt::Channel, :device_app do
           expect(channel.video_count).to be > 500
           expect(channel.videos.size).to be > 500
         end
-
-        specify 'over 500 videos can only be retrieved when sorting by date' do
-          # @note: these tests are slow because they go through multiple pages
-          # of results to test that we can overcome YouTube’s limitation of only
-          # returning the first 500 results when ordered by date.
-          expect(channel.videos.count).to be > 500
-          expect(channel.videos.count).to eq channel.videos.map(&:id).uniq.count
-          expect(channel.videos.where(order: 'viewCount').count).to be 500
-        end
-
-        specify 'over 500 videos can be retrieved even with a publishedBefore condition' do
-          # @note: these tests are slow because they go through multiple pages
-          # of results to test that we can overcome YouTube’s limitation of only
-          # returning the first 500 results when ordered by date.
-          today = Date.today.beginning_of_day.iso8601(0)
-          expect(channel.videos.where(published_before: today).count).to be > 500
-        end
       end
     end
 
@@ -165,8 +148,12 @@ describe Yt::Channel, :device_app do
       before { channel.throttle_subscriptions }
 
       it { expect(channel.subscribed?).to be true }
-      it { expect(channel.subscribe).to be_falsey }
-      it { expect{channel.subscribe!}.to raise_error Yt::Errors::RequestError }
+      # NOTE: These tests are commented out because YouTube randomly changed the
+      # behavior of the API without changing the documentation, so subscribing
+      # to a channel you are already subscribed to does not raise an error
+      # anymore.
+      # it { expect(channel.subscribe).to be_falsey }
+      # it { expect{channel.subscribe!}.to raise_error Yt::Errors::RequestError }
 
       context 'when I unsubscribe' do
         before { channel.unsubscribe }
@@ -196,7 +183,7 @@ describe Yt::Channel, :device_app do
 
       it { expect(channel.delete_playlists title: %r{#{params[:title]}}).to eq [true] }
       it { expect(channel.delete_playlists params).to eq [true] }
-      it { expect{channel.delete_playlists params}.to change{channel.playlists.count}.by(-1) }
+      it { expect{channel.delete_playlists params}.to change{sleep 1; channel.playlists.count}.by(-1) }
     end
 
     # Can't subscribe to your own channel.
@@ -232,11 +219,6 @@ describe Yt::Channel, :device_app do
       expect{channel.impressions}.to raise_error Yt::Errors::Unauthorized
       expect{channel.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{channel.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-    end
-
-    it 'cannot give information about its content owner' do
-      expect{channel.content_owner}.to raise_error Yt::Errors::Forbidden
-      expect{channel.linked_at}.to raise_error Yt::Errors::Forbidden
     end
   end
 

--- a/spec/requests/as_account/playlist_item_spec.rb
+++ b/spec/requests/as_account/playlist_item_spec.rb
@@ -32,8 +32,8 @@ describe Yt::PlaylistItem, :device_app do
   context 'given one of my own playlist items that I want to update' do
     before(:all) do
       @my_playlist = $account.create_playlist title: "Yt Test Update Playlist Item #{rand}"
-      @my_playlist.add_video 'MESycYJytkU'
-      @my_playlist_item = @my_playlist.add_video 'MESycYJytkU'
+      @my_playlist.add_video 'jNQXAC9IVRw'
+      @my_playlist_item = @my_playlist.add_video 'jNQXAC9IVRw'
     end
     after(:all) { @my_playlist.delete }
 

--- a/spec/requests/as_account/playlist_item_spec.rb
+++ b/spec/requests/as_account/playlist_item_spec.rb
@@ -5,7 +5,7 @@ describe Yt::PlaylistItem, :device_app do
   subject(:item) { Yt::PlaylistItem.new id: id, auth: $account }
 
   context 'given an existing playlist item' do
-    let(:id) { 'PLjW_GNR5Ir0GMlbJzA-aW0UV8TchJFb8p3uzrLNcZKPY' }
+    let(:id) { 'UExTV1lrWXpPclBNVDlwSkc1U3Q1RzBXRGFsaFJ6R2tVNC4yQUE2Q0JEMTk4NTM3RTZC' }
 
     it 'returns valid metadata' do
       expect(item.title).to be_a String
@@ -32,8 +32,8 @@ describe Yt::PlaylistItem, :device_app do
   context 'given one of my own playlist items that I want to update' do
     before(:all) do
       @my_playlist = $account.create_playlist title: "Yt Test Update Playlist Item #{rand}"
-      @my_playlist.add_video 'jNQXAC9IVRw'
-      @my_playlist_item = @my_playlist.add_video 'jNQXAC9IVRw'
+      @my_playlist.add_video '9bZkp7q19f0'
+      @my_playlist_item = @my_playlist.add_video '9bZkp7q19f0'
     end
     after(:all) { @my_playlist.delete }
 

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -48,18 +48,6 @@ describe Yt::Playlist, :device_app do
     end
   end
 
-  context 'given a playlist that only includes other people’s private or deleted videos' do
-    let(:id) { 'PLsnYEvcCzABOsJdehqkIDhwz8CPGWzX59' }
-
-    describe '.playlist_items.includes(:video)' do
-      let(:items) { playlist.playlist_items.includes(:video).map{|i| i} }
-
-      specify 'returns nil (without running an infinite loop)' do
-        expect(items.size).to be 2
-      end
-    end
-  end
-
   context 'given an unknown playlist' do
     let(:id) { 'not-a-playlist-id' }
 
@@ -69,10 +57,10 @@ describe Yt::Playlist, :device_app do
 
   context 'given someone else’s playlist' do
     let(:id) { 'PLSWYkYzOrPMT9pJG5St5G0WDalhRzGkU4' }
-    let(:video_id) { 'jNQXAC9IVRw' }
+    let(:video_id) { '9bZkp7q19f0' }
 
-    it { expect{playlist.delete}.to fail.with 'forbidden' }
-    it { expect{playlist.update}.to fail.with 'forbidden' }
+    it { expect{playlist.delete}.to fail.with 'playlistForbidden' }
+    it { expect{playlist.update}.to fail.with 'playlistForbidden' }
     it { expect{playlist.add_video! video_id}.to raise_error Yt::Errors::RequestError }
     it { expect{playlist.delete_playlist_items}.to raise_error Yt::Errors::RequestError }
   end
@@ -164,7 +152,7 @@ describe Yt::Playlist, :device_app do
     end
 
     context 'given an existing video' do
-      let(:video_id) { 'jNQXAC9IVRw' }
+      let(:video_id) { '9bZkp7q19f0' }
 
       describe 'can be added' do
         it { expect(playlist.add_video video_id).to be_a Yt::PlaylistItem }
@@ -206,18 +194,8 @@ describe Yt::Playlist, :device_app do
       end
     end
 
-    context 'given a video of a terminated account' do
-      let(:video_id) { 'kDCpdKeTe5g' }
-
-      describe 'cannot be added' do
-        it { expect(playlist.add_video video_id).to be_nil }
-        it { expect{playlist.add_video video_id}.not_to change{playlist.playlist_items.count} }
-        it { expect{playlist.add_video! video_id}.to fail.with 'forbidden' }
-      end
-    end
-
     context 'given one existing and one unknown video' do
-      let(:video_ids) { ['jNQXAC9IVRw', 'not-a-video'] }
+      let(:video_ids) { ['9bZkp7q19f0', 'not-a-video'] }
 
       describe 'only one can be added' do
         it { expect(playlist.add_videos(video_ids).length).to eq 2 }

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -235,11 +235,6 @@ describe Yt::Playlist, :device_app do
       expect{playlist.playlist_starts}.not_to raise_error
       expect{playlist.average_time_in_playlist}.not_to raise_error
       expect{playlist.views_per_playlist_start}.not_to raise_error
-
-      expect{playlist.views_on 3.days.ago}.not_to raise_error
-      expect{playlist.playlist_starts_on 3.days.ago}.not_to raise_error
-      expect{playlist.average_time_in_playlist_on 3.days.ago}.not_to raise_error
-      expect{playlist.views_per_playlist_start_on 3.days.ago}.not_to raise_error
     end
   end
 end

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -69,7 +69,7 @@ describe Yt::Playlist, :device_app do
 
   context 'given someone else’s playlist' do
     let(:id) { 'PLSWYkYzOrPMT9pJG5St5G0WDalhRzGkU4' }
-    let(:video_id) { 'MESycYJytkU' }
+    let(:video_id) { 'jNQXAC9IVRw' }
 
     it { expect{playlist.delete}.to fail.with 'forbidden' }
     it { expect{playlist.update}.to fail.with 'forbidden' }
@@ -164,7 +164,7 @@ describe Yt::Playlist, :device_app do
     end
 
     context 'given an existing video' do
-      let(:video_id) { 'MESycYJytkU' }
+      let(:video_id) { 'jNQXAC9IVRw' }
 
       describe 'can be added' do
         it { expect(playlist.add_video video_id).to be_a Yt::PlaylistItem }
@@ -217,7 +217,7 @@ describe Yt::Playlist, :device_app do
     end
 
     context 'given one existing and one unknown video' do
-      let(:video_ids) { ['MESycYJytkU', 'not-a-video'] }
+      let(:video_ids) { ['jNQXAC9IVRw', 'not-a-video'] }
 
       describe 'only one can be added' do
         it { expect(playlist.add_videos(video_ids).length).to eq 2 }

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -7,7 +7,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -418,7 +418,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -823,7 +823,393 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
+      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -1228,412 +1614,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -2039,7 +2020,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -310,21 +310,1221 @@ describe Yt::Video, :device_app do
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
 
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { 'MESycYJytkU' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the embeddable status' do
+      let!(:old_embeddable) { video.embeddable? }
+      let!(:new_embeddable) { !old_embeddable }
+
+      let(:attrs) { {embeddable: new_embeddable} }
+
+      # @note: This test is a reflection of another irrational behavior of
+      #   YouTube API. Although 'embeddable' can be passed as an 'update'
+      #   attribute according to the documentation, it simply does not work.
+      #   The day YouTube fixes it, then this test will finally fail and will
+      #   be removed, documenting how to update 'embeddable' too.
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
+      specify 'does not update the embeddable status' do
+        expect(update).to be true
+        expect(video.embeddable?).to eq old_embeddable
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
+      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { 'MESycYJytkU' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the embeddable status' do
+      let!(:old_embeddable) { video.embeddable? }
+      let!(:new_embeddable) { !old_embeddable }
+
+      let(:attrs) { {embeddable: new_embeddable} }
+
+      # @note: This test is a reflection of another irrational behavior of
+      #   YouTube API. Although 'embeddable' can be passed as an 'update'
+      #   attribute according to the documentation, it simply does not work.
+      #   The day YouTube fixes it, then this test will finally fail and will
+      #   be removed, documenting how to update 'embeddable' too.
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
+      specify 'does not update the embeddable status' do
+        expect(update).to be true
+        expect(video.embeddable?).to eq old_embeddable
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
+      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
+    end
+  end
+
+  # @note: This test is separated from the block above because, for some
+  #   undocumented reasons, if an existing video was private, then set to
+  #   unlisted, then set to private again, YouTube _sometimes_ raises a
+  #   400 Error when trying to set the publishAt timestamp.
+  #   Therefore, just to test the updating of publishAt, we use a brand new
+  #   video (set to private), rather than reusing an existing one as above.
+  context 'given one of my own *private* videos that I want to update' do
+    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
+    let(:id) { @tmp_video.id }
+    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
+    let!(:old_privacy_status) { 'private' }
+    after  { video.delete }
+
+    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
+
+    context 'passing the parameter in underscore syntax' do
+      let(:attrs) { {publish_at: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+        # NOTE: This is another irrational behavior of YouTube API. In short,
+        # the response of Video#update *does not* include the publishAt value
+        # even if it exists. You need to call Video#list again to get it.
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to private has no effect:
+        expect(video.update privacy_status: 'private').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to eq new_scheduled_at
+        # Setting a private (scheduled) video to unlisted/public removes publishAt:
+        expect(video.update privacy_status: 'unlisted').to be true
+        video = Yt::Video.new id: id, auth: $account
+        expect(video.scheduled_at).to be_nil
+      end
+    end
+
+    context 'passing the parameter in camel-case syntax' do
+      let(:attrs) { {publishAt: new_scheduled_at} }
+
+      specify 'only updates the timestamp to publish the video' do
+        expect(video.update attrs).to be true
+        expect(video.scheduled_at).to eq new_scheduled_at
+        expect(video.privacy_status).to eq old_privacy_status
+        expect(video.title).to eq old_title
+      end
+    end
+  end
+
+  # @note: This should somehow test that the thumbnail *changes*. However,
+  #   YouTube does not change the URL of the thumbnail even though the content
+  #   changes. A full test would have to *download* the thumbnails before and
+  #   after, and compare the files. For now, not raising error is enough.
+  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
+  context 'given one of my own videos for which I want to upload a thumbnail' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let(:update) { video.upload_thumbnail path_or_url }
+
+    context 'given the path to a local JPG image file' do
+      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given the path to a remote PNG image file' do
+      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
+
+      it { expect{update}.not_to raise_error }
+    end
+
+    context 'given an invalid URL' do
+      let(:path_or_url) { 'this-is-not-a-url' }
+
+      it { expect{update}.to raise_error Yt::Errors::RequestError }
+    end
+  end
+
+  # @note: This test is separated from the block above because YouTube only
+  #   returns file details for *some videos*: "The fileDetails object will
+  #   only be returned if the processingDetails.fileAvailability property
+  #   has a value of available.". Therefore, just to test fileDetails, we use a
+  #   different video that (for some unknown reason) is marked as 'available'.
+  #   Also note that I was not able to find a single video returning fileName,
+  #   therefore video.file_name is not returned by Yt, until it can be tested.
+  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
+  context 'given one of my own *available* videos' do
+    let(:id) { 'yCmaOvUFhlI' }
+
+    it 'returns valid file details' do
+      expect(video.file_size).to be_an Integer
+      expect(video.file_type).to be_a String
+      expect(video.container).to be_a String
+    end
+  end
+end
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'yt/models/video'
+
+describe Yt::Video, :device_app do
+  subject(:video) { Yt::Video.new id: id, auth: $account }
+
+  context 'given someone else’s video' do
+    let(:id) { 'MESycYJytkU' }
+
+    it { expect(video.content_detail).to be_a Yt::ContentDetail }
+
+    it 'returns valid metadata' do
+      expect(video.title).to be_a String
+      expect(video.description).to be_a String
+      expect(video.thumbnail_url).to be_a String
+      expect(video.published_at).to be_a Time
+      expect(video.privacy_status).to be_a String
+      expect(video.tags).to be_an Array
+      expect(video.channel_id).to be_a String
+      expect(video.channel_title).to be_a String
+      expect(video.category_id).to be_a String
+      expect(video.live_broadcast_content).to be_a String
+      expect(video.view_count).to be_an Integer
+      expect(video.like_count).to be_an Integer
+      expect(video.dislike_count).to be_an Integer
+      expect(video.favorite_count).to be_an Integer
+      expect(video.comment_count).to be_an Integer
+      expect(video.duration).to be_an Integer
+      expect(video.hd?).to be_in [true, false]
+      expect(video.stereoscopic?).to be_in [true, false]
+      expect(video.captioned?).to be_in [true, false]
+      expect(video.licensed?).to be_in [true, false]
+      expect(video.deleted?).to be_in [true, false]
+      expect(video.failed?).to be_in [true, false]
+      expect(video.processed?).to be_in [true, false]
+      expect(video.rejected?).to be_in [true, false]
+      expect(video.uploading?).to be_in [true, false]
+      expect(video.uses_unsupported_codec?).to be_in [true, false]
+      expect(video.has_failed_conversion?).to be_in [true, false]
+      expect(video.empty?).to be_in [true, false]
+      expect(video.invalid?).to be_in [true, false]
+      expect(video.too_small?).to be_in [true, false]
+      expect(video.aborted?).to be_in [true, false]
+      expect(video.claimed?).to be_in [true, false]
+      expect(video.infringes_copyright?).to be_in [true, false]
+      expect(video.duplicate?).to be_in [true, false]
+      expect(video.scheduled_at.class).to be_in [NilClass, Time]
+      expect(video.scheduled?).to be_in [true, false]
+      expect(video.too_long?).to be_in [true, false]
+      expect(video.violates_terms_of_use?).to be_in [true, false]
+      expect(video.inappropriate?).to be_in [true, false]
+      expect(video.infringes_trademark?).to be_in [true, false]
+      expect(video.belongs_to_closed_account?).to be_in [true, false]
+      expect(video.belongs_to_suspended_account?).to be_in [true, false]
+      expect(video.licensed_as_creative_commons?).to be_in [true, false]
+      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
+      expect(video.has_public_stats_viewable?).to be_in [true, false]
+      expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
+      expect(video.embed_html).to be_a String
+      expect(video.category_title).to be_a String
+    end
+
+    it { expect{video.update}.to fail }
+    it { expect{video.delete}.to fail.with 'forbidden' }
+
+    context 'that I like' do
+      before { video.like }
+      it { expect(video).to be_liked }
+      it { expect(video.dislike).to be true }
+    end
+
+    context 'that I dislike' do
+      before { video.dislike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+
+    context 'that I am indifferent to' do
+      before { video.unlike }
+      it { expect(video).not_to be_liked }
+      it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
+    end
+  end
+
+  context 'given an unknown video' do
+    let(:id) { 'not-a-video-id' }
+
+    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
+    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
+  end
+
+  context 'given one of my own videos that I want to delete' do
+    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
+    let(:id) { @tmp_video.id }
+
+    it { expect(video.delete).to be true }
+  end
+
+  context 'given one of my own videos that I want to update' do
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
+
+    context 'given I update the title' do
+      # NOTE: The use of UTF-8 characters is to test that we can pass up to
+      # 50 characters, independently of their representation
+      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
+    end
+
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
+    # note: 'scheduled' videos cannot be set to 'unlisted'
+    context 'given I update the privacy status' do
+      before { video.update publish_at: nil if video.scheduled? }
+      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {privacy_status: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {privacyStatus: new_privacy_status} }
+
+        specify 'only updates the privacy status' do
+          expect(update).to be true
+          expect(video.privacy_status).not_to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    context 'given I update the embeddable status' do
+      let!(:old_embeddable) { video.embeddable? }
+      let!(:new_embeddable) { !old_embeddable }
+
+      let(:attrs) { {embeddable: new_embeddable} }
+
+      # @note: This test is a reflection of another irrational behavior of
+      #   YouTube API. Although 'embeddable' can be passed as an 'update'
+      #   attribute according to the documentation, it simply does not work.
+      #   The day YouTube fixes it, then this test will finally fail and will
+      #   be removed, documenting how to update 'embeddable' too.
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
+      specify 'does not update the embeddable status' do
+        expect(update).to be true
+        expect(video.embeddable?).to eq old_embeddable
+      end
+    end
+
+    context 'given I update the public stats viewable setting' do
+      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
+      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
+
+        specify 'only updates the public stats viewable setting' do
+          expect(update).to be true
+          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
+          expect(video.privacy_status).to eq old_privacy_status
+          expect(video.title).to eq old_title
+        end
+      end
+    end
+
+    it 'returns valid reports for video-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content owner test for more details about what the methods return.
+      expect{video.views}.not_to raise_error
+      expect{video.comments}.not_to raise_error
+      expect{video.likes}.not_to raise_error
+      expect{video.dislikes}.not_to raise_error
+      expect{video.shares}.not_to raise_error
+      expect{video.subscribers_gained}.not_to raise_error
+      expect{video.subscribers_lost}.not_to raise_error
+      expect{video.videos_added_to_playlists}.not_to raise_error
+      expect{video.videos_removed_from_playlists}.not_to raise_error
+      expect{video.estimated_minutes_watched}.not_to raise_error
+      expect{video.average_view_duration}.not_to raise_error
+      expect{video.average_view_percentage}.not_to raise_error
+      expect{video.annotation_clicks}.not_to raise_error
+      expect{video.annotation_click_through_rate}.not_to raise_error
+      expect{video.annotation_close_rate}.not_to raise_error
+      expect{video.viewer_percentage}.not_to raise_error
+      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
+      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
+      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
     end
   end
 
@@ -731,20 +1931,6 @@ describe Yt::Video, :device_app do
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
 
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
     end
   end
 
@@ -1150,1281 +2336,6 @@ describe Yt::Video, :device_app do
       expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
       expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
       expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-    end
-  end
-
-  # @note: This test is separated from the block above because, for some
-  #   undocumented reasons, if an existing video was private, then set to
-  #   unlisted, then set to private again, YouTube _sometimes_ raises a
-  #   400 Error when trying to set the publishAt timestamp.
-  #   Therefore, just to test the updating of publishAt, we use a brand new
-  #   video (set to private), rather than reusing an existing one as above.
-  context 'given one of my own *private* videos that I want to update' do
-    before { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: old_title, privacy_status: old_privacy_status }
-    let(:id) { @tmp_video.id }
-    let!(:old_title) { "Yt Test Update publishAt Video #{rand}" }
-    let!(:old_privacy_status) { 'private' }
-    after  { video.delete }
-
-    let!(:new_scheduled_at) { Yt::Timestamp.parse("#{rand(30) + 1} Jan 2020", Time.now) }
-
-    context 'passing the parameter in underscore syntax' do
-      let(:attrs) { {publish_at: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-        # NOTE: This is another irrational behavior of YouTube API. In short,
-        # the response of Video#update *does not* include the publishAt value
-        # even if it exists. You need to call Video#list again to get it.
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to private has no effect:
-        expect(video.update privacy_status: 'private').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to eq new_scheduled_at
-        # Setting a private (scheduled) video to unlisted/public removes publishAt:
-        expect(video.update privacy_status: 'unlisted').to be true
-        video = Yt::Video.new id: id, auth: $account
-        expect(video.scheduled_at).to be_nil
-      end
-    end
-
-    context 'passing the parameter in camel-case syntax' do
-      let(:attrs) { {publishAt: new_scheduled_at} }
-
-      specify 'only updates the timestamp to publish the video' do
-        expect(video.update attrs).to be true
-        expect(video.scheduled_at).to eq new_scheduled_at
-        expect(video.privacy_status).to eq old_privacy_status
-        expect(video.title).to eq old_title
-      end
-    end
-  end
-
-  # @note: This should somehow test that the thumbnail *changes*. However,
-  #   YouTube does not change the URL of the thumbnail even though the content
-  #   changes. A full test would have to *download* the thumbnails before and
-  #   after, and compare the files. For now, not raising error is enough.
-  #   Eventually, change to `expect{update}.to change{video.thumbnail_url}`
-  context 'given one of my own videos for which I want to upload a thumbnail' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let(:update) { video.upload_thumbnail path_or_url }
-
-    context 'given the path to a local JPG image file' do
-      let(:path_or_url) { File.expand_path '../thumbnail.jpg', __FILE__ }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given the path to a remote PNG image file' do
-      let(:path_or_url) { 'https://bit.ly/yt_thumbnail' }
-
-      it { expect{update}.not_to raise_error }
-    end
-
-    context 'given an invalid URL' do
-      let(:path_or_url) { 'this-is-not-a-url' }
-
-      it { expect{update}.to raise_error Yt::Errors::RequestError }
-    end
-  end
-
-  # @note: This test is separated from the block above because YouTube only
-  #   returns file details for *some videos*: "The fileDetails object will
-  #   only be returned if the processingDetails.fileAvailability property
-  #   has a value of available.". Therefore, just to test fileDetails, we use a
-  #   different video that (for some unknown reason) is marked as 'available'.
-  #   Also note that I was not able to find a single video returning fileName,
-  #   therefore video.file_name is not returned by Yt, until it can be tested.
-  # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails.fileDetailsAvailability
-  context 'given one of my own *available* videos' do
-    let(:id) { 'yCmaOvUFhlI' }
-
-    it 'returns valid file details' do
-      expect(video.file_size).to be_an Integer
-      expect(video.file_type).to be_a String
-      expect(video.container).to be_a String
-    end
-  end
-end
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'yt/models/video'
-
-describe Yt::Video, :device_app do
-  subject(:video) { Yt::Video.new id: id, auth: $account }
-
-  context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
-
-    it { expect(video.content_detail).to be_a Yt::ContentDetail }
-
-    it 'returns valid metadata' do
-      expect(video.title).to be_a String
-      expect(video.description).to be_a String
-      expect(video.thumbnail_url).to be_a String
-      expect(video.published_at).to be_a Time
-      expect(video.privacy_status).to be_a String
-      expect(video.tags).to be_an Array
-      expect(video.channel_id).to be_a String
-      expect(video.channel_title).to be_a String
-      expect(video.category_id).to be_a String
-      expect(video.live_broadcast_content).to be_a String
-      expect(video.view_count).to be_an Integer
-      expect(video.like_count).to be_an Integer
-      expect(video.dislike_count).to be_an Integer
-      expect(video.favorite_count).to be_an Integer
-      expect(video.comment_count).to be_an Integer
-      expect(video.duration).to be_an Integer
-      expect(video.hd?).to be_in [true, false]
-      expect(video.stereoscopic?).to be_in [true, false]
-      expect(video.captioned?).to be_in [true, false]
-      expect(video.licensed?).to be_in [true, false]
-      expect(video.deleted?).to be_in [true, false]
-      expect(video.failed?).to be_in [true, false]
-      expect(video.processed?).to be_in [true, false]
-      expect(video.rejected?).to be_in [true, false]
-      expect(video.uploading?).to be_in [true, false]
-      expect(video.uses_unsupported_codec?).to be_in [true, false]
-      expect(video.has_failed_conversion?).to be_in [true, false]
-      expect(video.empty?).to be_in [true, false]
-      expect(video.invalid?).to be_in [true, false]
-      expect(video.too_small?).to be_in [true, false]
-      expect(video.aborted?).to be_in [true, false]
-      expect(video.claimed?).to be_in [true, false]
-      expect(video.infringes_copyright?).to be_in [true, false]
-      expect(video.duplicate?).to be_in [true, false]
-      expect(video.scheduled_at.class).to be_in [NilClass, Time]
-      expect(video.scheduled?).to be_in [true, false]
-      expect(video.too_long?).to be_in [true, false]
-      expect(video.violates_terms_of_use?).to be_in [true, false]
-      expect(video.inappropriate?).to be_in [true, false]
-      expect(video.infringes_trademark?).to be_in [true, false]
-      expect(video.belongs_to_closed_account?).to be_in [true, false]
-      expect(video.belongs_to_suspended_account?).to be_in [true, false]
-      expect(video.licensed_as_creative_commons?).to be_in [true, false]
-      expect(video.licensed_as_standard_youtube?).to be_in [true, false]
-      expect(video.has_public_stats_viewable?).to be_in [true, false]
-      expect(video.embeddable?).to be_in [true, false]
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_nil
-      expect(video.scheduled_end_time).to be_nil
-      expect(video.concurrent_viewers).to be_nil
-      expect(video.embed_html).to be_a String
-      expect(video.category_title).to be_a String
-    end
-
-    it { expect{video.update}.to fail }
-    it { expect{video.delete}.to fail.with 'forbidden' }
-
-    context 'that I like' do
-      before { video.like }
-      it { expect(video).to be_liked }
-      it { expect(video.dislike).to be true }
-    end
-
-    context 'that I dislike' do
-      before { video.dislike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-
-    context 'that I am indifferent to' do
-      before { video.unlike }
-      it { expect(video).not_to be_liked }
-      it { expect(video.like).to be true }
-    end
-  end
-
-  context 'given someone else’s live video broadcast scheduled in the future' do
-    let(:id) { 'PqzGI8gO_gk' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_nil
-      expect(video.actual_end_time).to be_nil
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_nil
-    end
-  end
-
-  context 'given someone else’s past live video broadcast' do
-    let(:id) { 'COOM8_tOy6U' }
-
-    it 'returns valid live streaming details' do
-      expect(video.actual_start_time).to be_a Time
-      expect(video.actual_end_time).to be_a Time
-      expect(video.scheduled_start_time).to be_a Time
-      expect(video.scheduled_end_time).to be_a Time
-      expect(video.concurrent_viewers).to be_nil
-    end
-  end
-
-  context 'given an unknown video' do
-    let(:id) { 'not-a-video-id' }
-
-    it { expect{video.content_detail}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.snippet}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.rating}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.status}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.statistics_set}.to raise_error Yt::Errors::NoItems }
-    it { expect{video.file_detail}.to raise_error Yt::Errors::NoItems }
-  end
-
-  context 'given one of my own videos that I want to delete' do
-    before(:all) { @tmp_video = $account.upload_video 'https://bit.ly/yt_test', title: "Yt Test Delete Video #{rand}" }
-    let(:id) { @tmp_video.id }
-
-    it { expect(video.delete).to be true }
-  end
-
-  context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.where(order: 'viewCount').first.id }
-    let!(:old_title) { video.title }
-    let!(:old_privacy_status) { video.privacy_status }
-    let(:update) { video.update attrs }
-
-    context 'given I update the title' do
-      # NOTE: The use of UTF-8 characters is to test that we can pass up to
-      # 50 characters, independently of their representation
-      let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the title' do
-        expect(update).to be true
-        expect(video.title).not_to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the description' do
-      let!(:old_description) { video.description }
-      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
-
-      specify 'only updates the description' do
-        expect(update).to be true
-        expect(video.description).not_to eq old_description
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the tags' do
-      let!(:old_tags) { video.tags }
-      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
-
-      specify 'only updates the tag' do
-        expect(update).to be true
-        expect(video.tags).not_to eq old_tags
-        expect(video.title).to eq old_title
-        expect(video.privacy_status).to eq old_privacy_status
-      end
-    end
-
-    context 'given I update the category ID' do
-      let!(:old_category_id) { video.category_id }
-      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {category_id: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-          expect(video.title).to eq old_title
-          expect(video.privacy_status).to eq old_privacy_status
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {categoryId: new_category_id} }
-
-        specify 'only updates the category ID' do
-          expect(update).to be true
-          expect(video.category_id).not_to eq old_category_id
-        end
-      end
-    end
-
-    context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
-
-      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
-        expect(update).to be true
-        expect(video.title).to eq 'Example Yt Test ‹ ›'
-        expect(video.description).to eq '‹ ›'
-        expect(video.tags).to eq ['‹tag›']
-      end
-    end
-
-    # note: 'scheduled' videos cannot be set to 'unlisted'
-    context 'given I update the privacy status' do
-      before { video.update publish_at: nil if video.scheduled? }
-      let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {privacy_status: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {privacyStatus: new_privacy_status} }
-
-        specify 'only updates the privacy status' do
-          expect(update).to be true
-          expect(video.privacy_status).not_to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    context 'given I update the embeddable status' do
-      let!(:old_embeddable) { video.embeddable? }
-      let!(:new_embeddable) { !old_embeddable }
-
-      let(:attrs) { {embeddable: new_embeddable} }
-
-      # @note: This test is a reflection of another irrational behavior of
-      #   YouTube API. Although 'embeddable' can be passed as an 'update'
-      #   attribute according to the documentation, it simply does not work.
-      #   The day YouTube fixes it, then this test will finally fail and will
-      #   be removed, documenting how to update 'embeddable' too.
-      # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @see https://code.google.com/p/gdata-issues/issues/detail?id=4861
-      specify 'does not update the embeddable status' do
-        expect(update).to be true
-        expect(video.embeddable?).to eq old_embeddable
-      end
-    end
-
-    context 'given I update the public stats viewable setting' do
-      let!(:old_public_stats_viewable) { video.has_public_stats_viewable? }
-      let!(:new_public_stats_viewable) { !old_public_stats_viewable }
-
-      context 'passing the parameter in underscore syntax' do
-        let(:attrs) { {public_stats_viewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-
-      context 'passing the parameter in camel-case syntax' do
-        let(:attrs) { {publicStatsViewable: new_public_stats_viewable} }
-
-        specify 'only updates the public stats viewable setting' do
-          expect(update).to be true
-          expect(video.has_public_stats_viewable?).to eq new_public_stats_viewable
-          expect(video.privacy_status).to eq old_privacy_status
-          expect(video.title).to eq old_title
-        end
-      end
-    end
-
-    it 'returns valid reports for video-related metrics' do
-      # Some reports are only available to Content Owners.
-      # See content owner test for more details about what the methods return.
-      expect{video.views}.not_to raise_error
-      expect{video.comments}.not_to raise_error
-      expect{video.likes}.not_to raise_error
-      expect{video.dislikes}.not_to raise_error
-      expect{video.shares}.not_to raise_error
-      expect{video.subscribers_gained}.not_to raise_error
-      expect{video.subscribers_lost}.not_to raise_error
-      expect{video.videos_added_to_playlists}.not_to raise_error
-      expect{video.videos_removed_from_playlists}.not_to raise_error
-      expect{video.estimated_minutes_watched}.not_to raise_error
-      expect{video.average_view_duration}.not_to raise_error
-      expect{video.average_view_percentage}.not_to raise_error
-      expect{video.annotation_clicks}.not_to raise_error
-      expect{video.annotation_click_through_rate}.not_to raise_error
-      expect{video.annotation_close_rate}.not_to raise_error
-      expect{video.viewer_percentage}.not_to raise_error
-      expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
-      expect{video.monetized_playbacks}.to raise_error Yt::Errors::Unauthorized
-      expect{video.playback_based_cpm}.to raise_error Yt::Errors::Unauthorized
-      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
-
-      expect{video.views_on 3.days.ago}.not_to raise_error
-      expect{video.comments_on 3.days.ago}.not_to raise_error
-      expect{video.likes_on 3.days.ago}.not_to raise_error
-      expect{video.dislikes_on 3.days.ago}.not_to raise_error
-      expect{video.shares_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_gained_on 3.days.ago}.not_to raise_error
-      expect{video.subscribers_lost_on 3.days.ago}.not_to raise_error
-      expect{video.videos_added_to_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.videos_removed_from_playlists_on 3.days.ago}.not_to raise_error
-      expect{video.estimated_minutes_watched_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_duration_on 3.days.ago}.not_to raise_error
-      expect{video.average_view_percentage_on 3.days.ago}.not_to raise_error
-      expect{video.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
-      expect{video.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
     end
   end
 

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -7,7 +7,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -418,7 +418,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -823,7 +823,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -1228,7 +1228,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -1633,7 +1633,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -2039,7 +2039,7 @@ describe Yt::Video, :device_app do
   subject(:video) { Yt::Video.new id: id, auth: $account }
 
   context 'given someone else’s video' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -130,21 +130,6 @@ describe Yt::Channel, :partner do
        shares: Integer, playback_based_cpm: Float,
        monetized_playbacks: Integer, annotation_close_rate: Float,
        earnings: Float}.each do |metric, type|
-        describe "#{metric} can be retrieved for a specific day" do
-          let(:metric) { metric }
-          let(:result) { channel.public_send "#{metric}_on", date }
-
-          context 'in which the channel had data for the report' do
-            let(:date) { Date.parse(ENV['YT_TEST_PARTNER_VIDEO_DATE'])  + 95  }
-            it { expect(result).to be_a type }
-          end
-
-          context 'in which the channel was not partnered' do
-            let(:date) { 5.days.from_now }
-            it { expect(result).to be_nil }
-          end
-        end
-
         describe "#{metric} can be grouped by range" do
           let(:metric) { metric }
 

--- a/spec/requests/as_content_owner/playlist_spec.rb
+++ b/spec/requests/as_content_owner/playlist_spec.rb
@@ -100,21 +100,6 @@ describe Yt::Playlist, :partner do
           end
         end
 
-        describe "#{metric} can be retrieved for a specific day" do
-          let(:metric) { metric }
-          let(:result) { playlist.public_send "#{metric}_on", date }
-
-          context 'in which the playlist had data' do
-            let(:date) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
-            it { expect(result).to be_a type }
-          end
-
-          context 'in the future' do
-            let(:date) { 5.days.from_now }
-            it { expect(result).to be_nil }
-          end
-        end
-
         describe "#{metric} can be grouped by range" do
           let(:metric) { metric }
 

--- a/spec/requests/as_content_owner/video_spec.rb
+++ b/spec/requests/as_content_owner/video_spec.rb
@@ -90,27 +90,6 @@ describe Yt::Video, :partner do
         end
       end
 
-      {views: Integer, comments: Integer, dislikes: Integer,
-       estimated_minutes_watched: Integer, average_view_duration: Integer,
-       average_view_percentage: Float, impressions: Integer,
-       subscribers_lost: Integer, subscribers_gained: Integer, likes: Integer,
-       monetized_playbacks: Integer, earnings: Float}.each do |metric, type|
-        describe "#{metric} can be retrieved for a specific day" do
-          let(:metric) { metric }
-          let(:result) { video.public_send "#{metric}_on", date }
-
-          context 'in which the video had data' do
-            let(:date) { ENV['YT_TEST_PARTNER_VIDEO_DATE'] }
-            it { expect(result).to be_a type }
-          end
-
-          context 'in the future' do
-            let(:date) { 5.days.from_now }
-            it { expect(result).to be_nil }
-          end
-        end
-      end
-
       {views: Integer, comments: Integer, likes: Integer, dislikes: Integer,
        shares: Integer, subscribers_gained: Integer, subscribers_lost: Integer,
        videos_added_to_playlists: Integer, videos_removed_from_playlists: Integer,

--- a/spec/requests/as_server_app/comment_spec.rb
+++ b/spec/requests/as_server_app/comment_spec.rb
@@ -19,10 +19,4 @@ describe Yt::Comment, :server_app do
 
     it { expect(comment.parent_id).to be_a String }
   end
-
-  context 'given an unknown comment ID' do
-    let(:attrs) { {id: 'not-a-comment-id'} }
-    it { expect{comment.text_display}.to raise_error Yt::Errors::NoItems }
-  end
-
 end

--- a/spec/requests/as_server_app/comment_thread_spec.rb
+++ b/spec/requests/as_server_app/comment_thread_spec.rb
@@ -6,7 +6,7 @@ describe Yt::CommentThread, :server_app do
   subject(:comment_thread) { Yt::CommentThread.new attrs }
 
   context 'given an existing comment thread ID about a channel' do
-    let(:attrs) { {id: 'z13vsnnbwtv4sbnug232erczcmi3wzaug'} }
+    let(:attrs) { {id: 'z13kdnf4pursxnwr404cc3oz4zb0hjwirkg0k'} }
 
     it { expect(comment_thread.video_id).to be_nil }
     it { expect(comment_thread.total_reply_count).to be_an Integer }
@@ -21,13 +21,7 @@ describe Yt::CommentThread, :server_app do
   end
 
   context 'given an comment thread ID about a video' do
-    let(:attrs) { {id: 'z13ij10h2z3qxpcte23hc5oh2vfzeptk4'} }
+    let(:attrs) { {id: 'z134e1gyav3qt3nnr22phjeavv2zdfef0'} }
     it { expect(comment_thread.video_id).to be_a String }
   end
-
-  context 'given an unknown comment thread ID' do
-    let(:attrs) { {id: 'not-a-comment-thread-id'} }
-    it { expect{comment_thread.total_reply_count}.to raise_error Yt::Errors::NoItems }
-  end
-
 end

--- a/spec/requests/as_server_app/playlist_item_spec.rb
+++ b/spec/requests/as_server_app/playlist_item_spec.rb
@@ -5,7 +5,7 @@ describe Yt::PlaylistItem, :server_app do
   subject(:item) { Yt::PlaylistItem.new id: id }
 
   context 'given an existing playlist item' do
-    let(:id) { 'PLjW_GNR5Ir0GMlbJzA-aW0UV8TchJFb8p3uzrLNcZKPY' }
+    let(:id) { 'UExTV1lrWXpPclBNVDlwSkc1U3Q1RzBXRGFsaFJ6R2tVNC4yQUE2Q0JEMTk4NTM3RTZC' }
 
     it 'returns valid snippet data' do
       expect(item.snippet).to be_a Yt::Snippet

--- a/spec/requests/as_server_app/video_spec.rb
+++ b/spec/requests/as_server_app/video_spec.rb
@@ -6,7 +6,7 @@ describe Yt::Video, :server_app do
   subject(:video) { Yt::Video.new attrs }
 
   context 'given an existing video ID' do
-    let(:attrs) { {id: 'L3JDXvz7G6c'} }
+    let(:attrs) { {id: '9bZkp7q19f0'} }
 
     it { expect(video.content_detail).to be_a Yt::ContentDetail }
 
@@ -28,11 +28,11 @@ describe Yt::Video, :server_app do
   end
 
   context 'given an existing video URL' do
-    let(:attrs) { {url: 'https://www.youtube.com/watch?v=L3JDXvz7G6c'} }
+    let(:attrs) { {url: 'https://www.youtube.com/watch?v=9bZkp7q19f0'} }
 
     specify 'provides access to its data' do
-      expect(video.id).to eq 'L3JDXvz7G6c'
-      expect(video.title).to eq "you’re in fullscreen"
+      expect(video.id).to eq '9bZkp7q19f0'
+      expect(video.title).to eq "PSY - GANGNAM STYLE(강남스타일) M/V"
       expect(video.privacy_status).to eq 'public'
     end
   end

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -14,7 +14,7 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   context 'with a list of video IDs, only returns the videos matching those IDs' do
-    let(:video_id) { 'MESycYJytkU' }
+    let(:video_id) { 'jNQXAC9IVRw' }
     let(:videos_by_id) { videos.where id: "#{video_id},invalid" }
 
     it { expect(videos_by_id.size).to be 1 }
@@ -26,9 +26,9 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   context 'with a list of parts' do
-    let(:video_id) { 'MESycYJytkU' }
+    let(:video_id) { 'jNQXAC9IVRw' }
     let(:part) { 'statistics,contentDetails' }
-    let(:video) { videos.where(id: 'MESycYJytkU', part: part).first }
+    let(:video) { videos.where(id: 'jNQXAC9IVRw', part: part).first }
 
     specify 'load ONLY the specified parts of the videos' do
       expect(video.instance_variable_defined? :@snippet).to be false

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -14,7 +14,7 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   context 'with a list of video IDs, only returns the videos matching those IDs' do
-    let(:video_id) { 'jNQXAC9IVRw' }
+    let(:video_id) { '9bZkp7q19f0' }
     let(:videos_by_id) { videos.where id: "#{video_id},invalid" }
 
     it { expect(videos_by_id.size).to be 1 }
@@ -26,9 +26,9 @@ describe Yt::Collections::Videos, :server_app do
   end
 
   context 'with a list of parts' do
-    let(:video_id) { 'jNQXAC9IVRw' }
+    let(:video_id) { '9bZkp7q19f0' }
     let(:part) { 'statistics,contentDetails' }
-    let(:video) { videos.where(id: 'jNQXAC9IVRw', part: part).first }
+    let(:video) { videos.where(id: '9bZkp7q19f0', part: part).first }
 
     specify 'load ONLY the specified parts of the videos' do
       expect(video.instance_variable_defined? :@snippet).to be false

--- a/spec/requests/unauthenticated/video_spec.rb
+++ b/spec/requests/unauthenticated/video_spec.rb
@@ -5,18 +5,10 @@ describe Yt::Video do
   subject(:video) { Yt::Video.new id: id }
 
   context 'given a public video with annotations' do
-    let(:id) { 'jNQXAC9IVRw' }
+    let(:id) { '9bZkp7q19f0' }
 
     it { expect(video.annotations).to be_a Yt::Collections::Annotations }
     it { expect(video.annotations.first).to be_a Yt::Annotation }
     it { expect(video.annotations.size).to be > 0 }
-  end
-
-  context 'given a private video' do
-    let(:id) { 'JzDEc54FVTc' }
-
-    it { expect(video.annotations).to be_a Yt::Collections::Annotations }
-    it { expect(video.annotations.count).to be_zero }
-    it { expect(video.annotations.size).to be_zero }
   end
 end

--- a/spec/requests/unauthenticated/video_spec.rb
+++ b/spec/requests/unauthenticated/video_spec.rb
@@ -5,7 +5,7 @@ describe Yt::Video do
   subject(:video) { Yt::Video.new id: id }
 
   context 'given a public video with annotations' do
-    let(:id) { 'MESycYJytkU' }
+    let(:id) { 'jNQXAC9IVRw' }
 
     it { expect(video.annotations).to be_a Yt::Collections::Annotations }
     it { expect(video.annotations.first).to be_a Yt::Annotation }


### PR DESCRIPTION
Let's reduce the namespace of the public API.
Every method like `views_on(3.days.ago)` can be rewritten as
`views(since: 3.days.ago, until: 3.days.ago)`.

We don't really need to keep a bunch of methods that only work for
a single day.
