### PR TITLE
Add #found? to Video, so we can check if any such video exists before…

### DIFF
--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -52,6 +52,11 @@ module Yt
         ensure_complete_snippet :category_id
       end
 
+      # @return [Boolean] Have we found a video on YouTube matching the ID?
+      def found?
+        snippets.any?
+      end
+
     ### STATUS ###
 
       # @return [Boolean] whether the video was deleted by the user.

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -666,4 +666,16 @@ describe Yt::Video do
       it { expect{video.delete}.to change{video.exists?} }
     end
   end
+
+  describe '#found?', server_app: true do
+    context "given an ID that doesn't match any YouTube video" do
+      let(:attrs) { {id: 'not-a-real-video'} }
+      it { expect(video).not_to be_found }
+    end
+
+    context "given an ID that matches something on YouTube" do
+      let(:attrs) { {id: 'dQw4w9WgXcQ'} }
+      it { expect(video).to be_found }
+    end
+  end
 end

--- a/yt.gemspec
+++ b/yt.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake' #, '~> 10.0'
   spec.add_development_dependency 'yard' #, '~> 0.8.0'
   spec.add_development_dependency 'coveralls' #, '~> 0.7.0'
+  spec.add_development_dependency 'simplecov', '~> 0.11.1'
 end


### PR DESCRIPTION
… raising NoItemErrors

I'm not sure this is the right way to implement such a method (or the right name to give it, but '#present? and #exists?' were taken. We wanted a way to just query the video object without it exploding if YouTube didn't recognise the ID we'd given it.

I update the Gemspec because I was getting errors from SimpleCov per the issue discussed [here](https://github.com/colszowka/simplecov/issues/428)