### PR TITLE
Don't raise errors for groups of playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.28.4 - 2017-01-18
+
+* [BUGFIX] Don't crash when Yt::VideoGroup is initialized with a group of playlists.
+
 ## 0.28.3 - 2017-01-09
 
 * [FEATURE] Add `VideoGroup#channels` method to load all channels under a group.

--- a/lib/yt/models/video_group.rb
+++ b/lib/yt/models/video_group.rb
@@ -150,6 +150,8 @@ module Yt
           resource_ids.flat_map do |channel_id|
             Yt::Channel.new(id: channel_id, auth: @auth).videos.map(&:id)
           end
+        else
+          []
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.28.3'
+  VERSION = '0.28.4'
 end


### PR DESCRIPTION
If someone tries to initialize a Yt::VideoGroup passing a group of
playlists, then the list of IDs should not be `nil` but an empty
array, so that the code doesn't crash when looping through them.