### PR TITLE
Don't raise errors for groups of playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.28.5 - 2017-01-18
+
+* [BUGFIX] Don't crash when Yt::VideoGroup is initialized with a group of playlists.
+
 ## 0.28.4 - 2017-01-18
 
 * [BUGFIX] Don't crash when Yt::VideoGroup is initialized with a group of playlists.

--- a/lib/yt/models/video_group.rb
+++ b/lib/yt/models/video_group.rb
@@ -172,6 +172,8 @@ module Yt
           end.uniq
         when "youtube#channel"
           resource_ids
+        else
+          []
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.28.4'
+  VERSION = '0.28.5'
 end


### PR DESCRIPTION
Same as b7af6bb0 but deals with the case of someone calling `.channels`
rather than `.videos`.