### PR TITLE
Fix YouTube API change: now include private videos

### DIFF
--- a/spec/playlist/items_spec.rb
+++ b/spec/playlist/items_spec.rb
@@ -53,9 +53,9 @@ describe 'Yt::Playlist#items', :server do
     end
 
     it 'accepts .limit to only fetch some items' do
-      expect(Net::HTTP).to receive(:start).twice.and_call_original
-      expect(playlist.items.select(:snippet).limit(42).count).to be 42
-      expect(playlist.items.select(:snippet).limit(42).count).to be 42
+      expect(Net::HTTP).to receive(:start).once.and_call_original
+      expect(playlist.items.select(:snippet).limit(2).count).to be 2
+      expect(playlist.items.select(:snippet).limit(2).count).to be 2
     end
   end
 end


### PR DESCRIPTION
Tests have started failing https://travis-ci.org/claudiob/yt/builds/200705205

The reason is probably that YouTube would not include private videos
in the result of playlistItems and now it does. This change is not
announced but does not affect the code. The test is still valid.