### PR TITLE
Stop non-existent channels causing Infinite loops on upload_video and create_playlist

### DIFF
--- a/lib/yt/actions/insert.rb
+++ b/lib/yt/actions/insert.rb
@@ -9,7 +9,17 @@ module Yt
 
     private
 
-      def do_insert(extra_insert_params = {})
+      def do_insert(extra_insert_params = {}, options = {})
+        if options[:required_channel]
+          check_channel_presence = proc do
+            begin
+              {errors:[{reason: 'channelNotFound', message: 'Channel not found.'}], message: 'Channel not found.'} unless options[:required_channel].status.is_linked?
+            rescue Errors::Unauthorized
+              nil
+            end
+          end
+          extra_insert_params = extra_insert_params.merge(unauthorized_api_method: check_channel_presence)
+        end
         response = insert_request(extra_insert_params).run
         @items = []
         new_item extract_data_from(response)

--- a/lib/yt/collections/playlists.rb
+++ b/lib/yt/collections/playlists.rb
@@ -4,6 +4,10 @@ module Yt
   module Collections
     class Playlists < Resources
 
+      def insert(attributes = {}, options = {})
+        super(attributes, options.merge(required_channel: @parent))
+      end
+
     private
 
       # @return [Hash] the parameters to submit to YouTube to list channels.

--- a/lib/yt/collections/resources.rb
+++ b/lib/yt/collections/resources.rb
@@ -9,11 +9,11 @@ module Yt
         do_delete_all params
       end
 
-      def insert(attributes = {}, options = {}) #
+      def insert(attributes = {}, options = {})
         underscore_keys! attributes
         body = build_insert_body attributes
         params = {part: body.keys.join(',')}
-        do_insert(params: params, body: body)
+        do_insert({params: params, body: body}, options)
       end
 
     private

--- a/lib/yt/collections/resumable_sessions.rb
+++ b/lib/yt/collections/resumable_sessions.rb
@@ -16,9 +16,9 @@ module Yt
       # URL to upload the object file (and eventually resume the upload).
       # @param [Integer] content_length the size (bytes) of the object to upload.
       # @param [Hash] body the metadata to add to the uploaded object.
-      def insert(content_length, body = {})
+      def insert(content_length, body = {}, options = {})
         @headers = headers_for content_length
-        do_insert body: body, headers: @headers
+        do_insert({body: body, headers: @headers}, options)
       end
 
     private

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -60,6 +60,7 @@ module Yt
     ### ACTIONS ###
 
       # Uploads a video to the account’s channel.
+      # If the account has no linked channel, a RequestError with reasons=['channelNotFound'] is raised.
       # @param [String] path_or_url the video to upload. Can either be the
       #   path of a local file or the URL of a remote file.
       # @param [Hash] params the metadata to add to the uploaded video.
@@ -70,7 +71,7 @@ module Yt
       # @return [Yt::Models::Video] the newly uploaded video.
       def upload_video(path_or_url, params = {})
         file = open path_or_url, 'rb'
-        session = resumable_sessions.insert file.size, upload_body(params)
+        session = resumable_sessions.insert file.size, upload_body(params), required_channel: channel
 
         session.update(body: file) do |data|
           Yt::Video.new id: data['id'], snippet: data['snippet'], status: data['privacyStatus'], auth: self
@@ -78,6 +79,7 @@ module Yt
       end
 
       # Creates a playlist in the account’s channel.
+      # If the account has no linked channel, a RequestError with reasons=['channelNotFound'] is raised.
       # @return [Yt::Models::Playlist] the newly created playlist.
       # @param [Hash] params the attributes of the playlist.
       # @option params [String] :title The new playlist’s title.

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -29,6 +29,16 @@ module Yt
       #   @return [Time] the date and time that the channel was created.
       delegate :published_at, to: :snippet
 
+    ### STATUS ###
+
+      # @!attribute [r] is_linked?
+      #   @return [Boolean] whether the channel is associated with a Google user
+      #   that is already linked to either a YouTube username or a Google+ account.
+      #   A user that has one of these links has a public YouTube identity,
+      #   which is a prerequisite for uploading videos and creating and deleting
+      #   playlists and playlist_items.
+      delegate :is_linked?, to: :status
+
     ### SUBSCRIPTION ###
 
       has_one :subscription

--- a/lib/yt/models/status.rb
+++ b/lib/yt/models/status.rb
@@ -27,6 +27,7 @@ module Yt
       has_attribute :embeddable
       has_attribute :public_stats_viewable
       has_attribute :publish_at, type: Time
+      has_attribute :is_linked?, from: :is_linked
     end
   end
 end


### PR DESCRIPTION
A Google account can lack a public-facing YouTube channel. Though such an account can still authenticate with YouTube scopes without error, video uploads and playlist/playlistItem creation/deletion fail. (However, interestingly, subscriptions succeed, though are not publicly shown.)

When a channel doesn't exist, deleting a playlist will fail with a `RequestError`, with reason "channelNotFound". However, in the same circumstances, `account#upload_video` and `account#create_playlist` enter infinite token-refresh loops because the API is returning an `Net::HTTPUnauthorized` error that YT treats as token expiry.

This pull request adds the channel#is_linked? attribute that allows a channel's existence to be tested. The PR also uses this attribute to prevent the infinite loops by changing the `Unauthorized` errors into `RequestErrors` with "channelNotFound" reasons, matching the behaviour of `delete_playlist`.

I haven't added tests yet, both because I'm not sure how to have the automated tests operate on a user without a channel, and because I don't want to waste time writing them if my approach isn't accepted.