### PR TITLE
Add 'include-historical-channel-data' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.31.2 - 2017-06-29
+
+* [BUGFIX] Return lifetime data correctly even when the channel joined content owner after a while since it's created.
+
 ## 0.31.1 - 2017-06-03
 
 * [FEATURE] Add `by: :youtube_product` option for reports.

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -188,6 +188,7 @@ module Yt
           params['end-date'] = @days_range.end
           params['metrics'] = @metrics.keys.join(',').to_s.camelize(:lower)
           params['dimensions'] = DIMENSIONS[@dimension][:name] unless @dimension == :range
+          params['include-historical-channel-data'] = 'true'
           params['max-results'] = 50 if @dimension.in? [:playlist, :video]
           params['max-results'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
           if @dimension.in? [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer]

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.31.1'
+  VERSION = '0.31.2'
 end


### PR DESCRIPTION
YouTube does not respond with the historical data (the data happened before the channel joined content owner) by default, if you manage it through the content owner.

https://developers.google.com/youtube/analytics/v1/reference/reports/query#include-historical-channel-data

But it also returns historical data with this parameter of value **true**. By this change, historical data always will be contained.