### PR TITLE
Add include-historical-channel-data by option historical: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.32.0 - 2017-07-05
+
+**How to upgrade**
+
+If your code is expecting data from `reports` methods to always include historical data (the data from the period before joining), now you have to set `historical: true` specifically. It will not include historical data by default.
+
+* [IMPROVEMENT] Include historical data with `historical: true` option.
+
 ## 0.31.2 - 2017-06-29
 
 * [BUGFIX] Return lifetime data correctly even when the channel joined content owner after a while since it's created.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.31.2'
+  VERSION = '0.32.0'
 end

--- a/spec/collections/reports_spec.rb
+++ b/spec/collections/reports_spec.rb
@@ -9,7 +9,7 @@ describe Yt::Collections::Reports do
   let(:msg) { {response_body: {error: {errors: [error]}}}.to_json }
 
   describe '#within' do
-    let(:result) { reports.within Range.new(5.days.ago, 4.days.ago), nil, nil, :day, nil }
+    let(:result) { reports.within Range.new(5.days.ago, 4.days.ago), nil, nil, :day, nil, nil }
     context 'given the request raises error 400 with "Invalid Query" message' do
       let(:reason) { 'badRequest' }
       let(:message) { 'Invalid query. Query did not conform to the expectations' }


### PR DESCRIPTION
By this change, include `include-historical-channel-data=true` or `include-historical-channel-data=false` option into the query only when `:historical` option being passed