### PR TITLE
Delegate all Enumerable methods to `list`. 

### DIFF
--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -6,8 +6,7 @@ require 'yt/config'
 module Yt
   module Actions
     module List
-      delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first, :take,
-        :flat_map, :map, :select, :size, to: :list
+      delegate *Enumerable.instance_methods, to: :list
 
       def first!
         first.tap{|item| raise Errors::NoItems, error_message unless item}


### PR DESCRIPTION
Avoiding the current surprising behavior of certain enumerable methods not being available
for List actions.