### PR TITLE
YouTube Analytics API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.32.2 - 2018-05-25
+
+* Use YouTube Analytics API v2 instead of v1. See announcement of v1 deprecation
+https://developers.google.com/youtube/analytics/revision_history#april-26-2018
+
 ## 0.32.1 - 2017-08-14
 
 * [FEATURE] Add `Yt::ContentOwner#bulk_report_jobs`

--- a/lib/yt/collections/group_infos.rb
+++ b/lib/yt/collections/group_infos.rb
@@ -14,7 +14,8 @@ module Yt
 
       def list_params
         super.tap do |params|
-          params[:path] = "/youtube/analytics/v1/groups"
+          params[:host] = 'youtubeanalytics.googleapis.com'
+          params[:path] = "/v2/groups"
           params[:params] = {id: @parent.id}
           if @auth.owner_name
             params[:params][:on_behalf_of_content_owner] = @auth.owner_name

--- a/lib/yt/collections/group_items.rb
+++ b/lib/yt/collections/group_items.rb
@@ -16,7 +16,8 @@ module Yt
 
       def list_params
         super.tap do |params|
-          params[:path] = "/youtube/analytics/v1/groupItems"
+          params[:host] = 'youtubeanalytics.googleapis.com'
+          params[:path] = "/v2/groupItems"
           params[:params] = {group_id: @parent.id}
           if @auth.owner_name
             params[:params][:on_behalf_of_content_owner] = @auth.owner_name

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -177,7 +177,8 @@ module Yt
       # @see https://developers.google.com/youtube/analytics/v1/content_owner_reports
       def list_params
         super.tap do |params|
-          params[:path] = '/youtube/analytics/v1/reports'
+          params[:host] = 'youtubeanalytics.googleapis.com'
+          params[:path] = '/v2/reports'
           params[:params] = reports_params
           params[:camelize_params] = false
         end
@@ -185,13 +186,13 @@ module Yt
 
       def reports_params
         @parent.reports_params.tap do |params|
-          params['start-date'] = @days_range.begin
-          params['end-date'] = @days_range.end
+          params['startDate'] = @days_range.begin
+          params['endDate'] = @days_range.end
           params['metrics'] = @metrics.keys.join(',').to_s.camelize(:lower)
           params['dimensions'] = DIMENSIONS[@dimension][:name] unless @dimension == :range
-          params['include-historical-channel-data'] = @historical if @historical
-          params['max-results'] = 50 if @dimension.in? [:playlist, :video]
-          params['max-results'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
+          params['includeHistoricalChannelData'] = @historical if @historical
+          params['maxResults'] = 50 if @dimension.in? [:playlist, :video]
+          params['maxResults'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
           if @dimension.in? [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer]
             if @metrics.keys == [:estimated_revenue, :estimated_minutes_watched]
               params['sort'] = '-estimatedRevenue'

--- a/lib/yt/collections/video_groups.rb
+++ b/lib/yt/collections/video_groups.rb
@@ -19,7 +19,8 @@ module Yt
 
       def list_params
         super.tap do |params|
-          params[:path] = "/youtube/analytics/v1/groups"
+          params[:host] = 'youtubeanalytics.googleapis.com'
+          params[:path] = "/v2/groups"
           params[:params] = @parent.video_groups_params
         end
       end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.32.1'
+  VERSION = '0.32.2'
 end


### PR DESCRIPTION
YouTube announced earlier they are deprecating v1 Analytics API
> Version 1 of the API (v1) is now deprecated and will be supported until October 31, 2018. 

https://developers.google.com/youtube/analytics/revision_history#april-26-2018

They said v1 will be supported until October 31, 2018... but when I tried yesterday and today the returned data was empty (when call with v1), and then I found when I tried with v2 it had response correctly.

So I think we need apply the upgrade in a hurry.

+ v2 
```
curl -X GET "https://youtubeanalytics.googleapis.com/v2/reports?endDate=2018-05-25&
filters=channel==UC...&ids=contentOwner==...&metrics=estimatedRevenue,
estimatedMinutesWatched&startDate=2005-02-01"

{
  "kind": "youtubeAnalytics#resultTable",
  "columnHeaders": [
    {
      "name": "estimatedRevenue",
      "columnType": "METRIC",
      "dataType": "FLOAT"
    },
    {
      "name": "estimatedMinutesWatched",
      "columnType": "METRIC",
      "dataType": "INTEGER"
    }
  ],
  "rows": [
    [
      39.859,
      388119984
    ]
  ]
}
```
+ v1
```
curl -X GET "https://www.googleapis.com/youtube/analytics/v1/reports?end-date=2018-05-25&
filters=channel==UC...&ids=contentOwner==...&metrics=estimatedRevenue,
estimatedMinutesWatched&start-date=2005-02-01"

{
 "kind": "youtubeAnalytics#resultTable",
 "columnHeaders": [
  {
   "name": "estimatedRevenue",
   "columnType": "METRIC",
   "dataType": "FLOAT"
  },
  {
   "name": "estimatedMinutesWatched",
   "columnType": "METRIC",
   "dataType": "INTEGER"
  }
 ]
}
```