### PR TITLE
Remove pagination with publishedAfter and publishedBefore

### DIFF
--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -19,7 +19,6 @@ module Yt
         @last_index, @page_token = 0, nil
         Yt::Iterator.new(-> {total_results}) do |items|
           while next_item = find_next
-            break if self.is_a?(Yt::Collections::Videos) && @last_index > 500
             items << next_item
           end
           @where_params = {}

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -19,6 +19,7 @@ module Yt
         @last_index, @page_token = 0, nil
         Yt::Iterator.new(-> {total_results}) do |items|
           while next_item = find_next
+            break if self.is_a?(Yt::Collections::Videos) && @last_index > 500
             items << next_item
           end
           @where_params = {}


### PR DESCRIPTION
Currently it loops infinitely when its parent channel has more than
500 videos. (it fetches for 10 pages, and then run the next query
with publishedAfter without page token and - because it doesn't work -
start over from the beginning because publishedAfter is ignored)

YouTube says it's only a temporary issue, but we'll see.
https://issuetracker.google.com/issues/128594402