### PR TITLE
adds match info to new youtube claims API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information about changelogs, check
 
 * [FEATURE] Add `ownership_effective` method to access asset ownership ("effective") via the asset object.
 * [FEATURE] List content owners of others with `content_owner.content_owners`
+* [FEATURE] Add `match_info` to insert claim request.
 
 ## 0.32.3 - 2019-03-15
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,32 @@ claim.claim_history #=> #<Yt::Models::ClaimHistory ...>
 claim.claim_history.events[0].type #=> "claim_create"
 
 claim.delete #=> true
+
+data = {
+  is_manual_claim: true,
+  content_type: 'audiovisual',
+  asset_id: 'A123123123123123',
+  policy: { id: 'S123123123123123' },
+  video_id: 'myvIdeoIdYT',
+  match_info: {
+    match_segments: [
+      {
+        manual_segment: {
+          start: '00:00:20.000',
+          finish: '00:01:20.000'
+        }
+      },
+      {
+        manual_segment: {
+          start: '00:02:30.000',
+          finish: '00:03:50.000'
+        }
+      }
+    ]
+  }
+}
+
+content_owner.claims.insert(data)
 ```
 
 *The methods above require to be authenticated as the video’s content owner (see below).*

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -11,6 +11,7 @@ module Yt
         underscore_keys! attributes
         body = attributes.slice :asset_id, :video_id, :content_type, :policy
         body[:policy] = {id: attributes[:policy_id]} if attributes[:policy_id]
+        body[:match_info] = match_attributes(attributes[:match_info]) if attributes[:match_info]
         params = attributes.slice(:is_manual_claim).merge({on_behalf_of_content_owner: @auth.owner_name})
         do_insert(params: params, body: body)
       end
@@ -36,6 +37,14 @@ module Yt
           end
         end
         super
+      end
+
+      def match_attributes(attributes = {})
+        attributes.tap do |match_data|
+          match_data[:match_segments] = match_data[:match_segments].map do |segment|
+            { manual_segment: (segment[:manual_segment] || segment).slice(:start, :finish) }
+          end
+        end
       end
 
       # @return [Hash] the parameters to submit to YouTube to list claims

--- a/spec/collections/claims_spec.rb
+++ b/spec/collections/claims_spec.rb
@@ -3,10 +3,35 @@ require 'yt/collections/claims'
 require 'yt/models/content_owner'
 
 describe Yt::Collections::Claims do
-  subject(:collection) { Yt::Collections::Claims.new parent: content_owner }
   let(:content_owner) { Yt::ContentOwner.new owner_name: 'any-name' }
+  let(:collection) { Yt::Collections::Claims.new parent: content_owner, auth: content_owner }
   let(:page) { {items: [], token: 'any-token'} }
   let(:query) { {q: 'search string'} }
+
+  describe "#insert" do
+    let(:attributes) {
+      {
+        asset_id: 'some_asset_id',
+        video_id: 'some_video_id',
+        content_type: 'audiovisual',
+        policy: { id: 'some_policy_id' },
+        match_info: { match_segments: [ { manual_segment: { start: "00:01:00.000", finish: "00:02:00.000" } } ] },
+        is_manual_claim: true
+      }
+    }
+
+    before do
+      allow(collection).to receive(:do_insert)
+      collection.insert(attributes.deep_dup)
+    end
+
+    it 'calls do_insert with appropriate body' do
+      expect(collection).to have_received(:do_insert).with(
+        params: { is_manual_claim: true, on_behalf_of_content_owner: content_owner.owner_name },
+        body: attributes.except(:is_manual_claim)
+      )
+    end
+  end
 
   describe '#count' do
     context 'called once with .where(query) and once without' do


### PR DESCRIPTION
A new requirement to include matching video segments for a claim against an asset is coming down the pipeline for the Youtube partner claims API. 

With this requirement, an API request body _may_ look something like:

```
  {
       'assetId': '<asset_id>',
       'contentType': 'audiovisual',
       'videoId': '<video_id>',
       'policy': {
         'id': '<policy_id>'
       },
       'blockOutsideOwnership': 'true',
       'matchInfo': {
           'matchSegments': [
               {
                   'manual_segment': {
                       'start': '00:00:20.000',
                       'finish': '00:01:20.000'
                   }
               },
               {
                   'manual_segment': {
                       'start': '00:02:00.000',
                       'finish': '00:03:30.000'
                   }
               }
           ]
       }
   }
```

This PR adds `matchInfo` to the body of the "insert claim" request. 

API Documentation: https://developers.google.com/youtube/partner/docs/v1/claims/insert
(Does not yet include information on match info or manual segments.)

Unknown: If each "manual_segment" hash key will be snake cased or will continue with camel case like with other attributes. 