### PR TITLE
Add Resource.new(url: <url>) syntax back to yt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-
-## Unreleased
+## 0.33.0 - Unreleased
 
 If your code calls reports methods such as `views`, `likes`, or `reports`,
 do not include `by: :week` option since `7DayTotals` dimension will no longer be
@@ -20,6 +19,11 @@ If you keep using `by: :week` option after this change it will raise an error
 the gem upgrade, like any other random input).
 
 * [REMOVAL] Remove `by: :week` option for reports.
+* [FEATURE] Add back the option of initializing a resource by its URL.
+
+**Breaking change**
+
+If your code is using constant `Yt::URL::CHANNEL_PATTERNS` etc then it's moved to `Yt::Resource::CHANNEL_PATTERNS`, `Yt::Resource::VIDEO_PATTERNS`, and `Yt::Resource::PLAYLIST_PATTERNS`.
 
 ## 0.32.6 - 2020-02-07
 
@@ -42,10 +46,6 @@ the gem upgrade, like any other random input).
 * [FEATURE] Add `upload_reference_file` method for Reference file upload (thank you @jcohenho)
 * [FEATURE] Get one asset [by request](https://developers.google.com/youtube/partner/docs/v1/assets/get) (thank you @jcohenho)
 * [FEATURE] Add `update` method to Yt::Claim (thank you @jcohenho)
-
-**Breaking change**
-
-If your code is using constant `Yt::URL::CHANNEL_PATTERNS` etc then it's moved to `Yt::Resource::CHANNEL_PATTERNS` etc.
 
 ## 0.32.3 - 2019-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ the gem upgrade, like any other random input).
 * [FEATURE] Get one asset [by request](https://developers.google.com/youtube/partner/docs/v1/assets/get) (thank you @jcohenho)
 * [FEATURE] Add `update` method to Yt::Claim (thank you @jcohenho)
 
+**Breaking change**
+
+If your code is using constant `Yt::URL::CHANNEL_PATTERNS` etc then it's moved to `Yt::Resource::CHANNEL_PATTERNS` etc.
+
 ## 0.32.3 - 2019-03-15
 
 * [ENHANCEMENT] Add `Yt::URL` to get id, kind, and its resource (channel, video, playlist)

--- a/YOUTUBE_IT.md
+++ b/YOUTUBE_IT.md
@@ -141,7 +141,7 @@ client = YouTubeIt::Client.new
 client.videos_by(:query => "penguin",  :author => "liz")
 # with yt: the 'author' filter was removed from YouTube API V3, so the
 # request must be done using the channel of the requested author
-channel = Yt::Channel.new id: 'UCxxxxxxxxx'
+channel = Yt::Channel.new url: 'youtube.com/liz'
 channel.videos.where(q: 'penguin')
 ```
 
@@ -176,7 +176,7 @@ client = YouTubeIt::Client.new
 client.videos_by(:user => 'liz')
 # with yt: the 'author' filter was removed from YouTube API V3, so the
 # request must be done using the channel of the requested author
-channel = Yt::Channel.new id: 'UCxxxxxxxxx'
+channel = Yt::Channel.new url: 'youtube.com/liz'
 channel.videos.where(q: 'penguin')
 ```
 
@@ -188,7 +188,7 @@ client = YouTubeIt::Client.new
 client.videos_by(:favorites, :user => 'liz')
 # with yt: note that only *old* channels have a "Favorites" playlist, since
 # "Favorites" has been deprecated by YouTube in favor of "Liked Videos".
-channel = Yt::Channel.new id: 'UCxxxxxxxxx'
+channel = Yt::Channel.new url: 'youtube.com/liz'
 channel.related_playlists.find{|p| p.title == 'Favorites'}
 ```
 

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -13,7 +13,6 @@ require 'yt/models/video_group'
 require 'yt/models/comment_thread'
 require 'yt/models/ownership'
 require 'yt/models/advertising_options_set'
-require 'yt/models/url'
 
 # An object-oriented Ruby client for YouTube.
 # Helps creating applications that need to interact with YouTube objects.

--- a/lib/yt/models/url.rb
+++ b/lib/yt/models/url.rb
@@ -14,18 +14,17 @@ module Yt
       # @param [String] text the name or URL of a YouTube resource (in any form).
       def initialize(text)
         @text = text.to_s.strip
-        @match = find_pattern_match
       end
 
       # @return [Symbol] the kind of YouTube resource matching the URL.
       # Possible values are: +:playlist+, +:video+, +:channel+, and +:unknown:.
       def kind
-        @match[:kind]
+        Resource.new(url: @text).kind.to_sym
       end
 
       # @return [<String, nil>] the ID of the YouTube resource matching the URL.
       def id
-        @match['id'] ||= fetch_id
+        Resource.new(url: @text).id
       end
 
       # @return [<Yt::Channel>] the resource associated with the URL
@@ -36,63 +35,6 @@ module Yt
           when :playlist then Yt::Playlist
           else raise Yt::Errors::NoItems
         end.new options.merge(id: id)
-      end
-
-      # @return [Array<Regexp>] patterns matching URLs of YouTube playlists.
-      PLAYLIST_PATTERNS = [
-         %r{^(?:https?://)?(?:www\.)?youtube\.com/playlist/?\?list=(?<id>[a-zA-Z0-9_-]+)},
-      ]
-
-      # @return [Array<Regexp>] patterns matching URLs of YouTube videos.
-      VIDEO_PATTERNS = [
-        %r{^(?:https?://)?(?:www\.)?youtube\.com/watch\?v=(?<id>[a-zA-Z0-9_-]{11})},
-        %r{^(?:https?://)?(?:www\.)?youtu\.be/(?<id>[a-zA-Z0-9_-]{11})},
-        %r{^(?:https?://)?(?:www\.)?youtube\.com/embed/(?<id>[a-zA-Z0-9_-]{11})},
-        %r{^(?:https?://)?(?:www\.)?youtube\.com/v/(?<id>[a-zA-Z0-9_-]{11})},
-      ]
-
-      # @return [Array<Regexp>] patterns matching URLs of YouTube channels.
-      CHANNEL_PATTERNS = [
-        %r{^(?:https?://)?(?:www\.)?youtube\.com/channel/(?<id>UC[a-zA-Z0-9_-]{22})},
-        %r{^(?:https?://)?(?:www\.)?youtube\.com/(?<format>c/|user/)?(?<name>[a-zA-Z0-9_-]+)}
-      ]
-
-    private
-
-      def find_pattern_match
-        patterns.find(-> {{kind: :unknown}}) do |kind, regex|
-          if data = @text.match(regex)
-            # Note: With Ruby 2.4, the following is data.named_captures
-            break data.names.zip(data.captures).to_h.merge kind: kind
-          end
-        end
-      end
-
-      def patterns
-        # @note: :channel *must* be the last since one of its regex eats the
-        # remaining patterns. In short, don't change the following order.
-        Enumerator.new do |patterns|
-          VIDEO_PATTERNS.each {|regex| patterns << [:video, regex]}
-          PLAYLIST_PATTERNS.each {|regex| patterns << [:playlist, regex]}
-          CHANNEL_PATTERNS.each {|regex| patterns << [:channel, regex]}
-        end
-      end
-
-      def fetch_id
-        response = Net::HTTP.start 'www.youtube.com', 443, use_ssl: true do |http|
-          http.request Net::HTTP::Get.new("/#{@match['format']}#{@match['name']}")
-        end
-        if response.is_a?(Net::HTTPRedirection)
-          response = Net::HTTP.start 'www.youtube.com', 443, use_ssl: true do |http|
-            http.request Net::HTTP::Get.new(response['location'])
-          end
-        end
-        regex = %r{<meta itemprop="channelId" content="(?<id>UC[a-zA-Z0-9_-]{22})">}
-        if data = response.body.match(regex)
-          data[:id]
-        else
-          raise Yt::Errors::NoItems
-        end
       end
     end
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -4,6 +4,13 @@ require 'yt/models/resource'
 describe Yt::Resource do
   subject(:resource) { Yt::Resource.new attrs }
 
+  context 'given a resource initialized with a URL (containing an ID)' do
+    let(:attrs) { {url: 'youtu.be/9bZkp7q19f0'} }
+
+    it { expect(resource.id).to eq '9bZkp7q19f0' }
+    it { expect(resource.kind).to eq 'video' }
+  end
+
   describe '#public?' do
     context 'given fetching a status returns privacyStatus "public"' do
       let(:attrs) { {status: {"privacyStatus"=>"public"}} }


### PR DESCRIPTION
I moved much code from url.rb to resource.rb to keep `url.resource` still work