### PR TITLE
Do not use api_key when auth is given, because unnecessary

### DIFF
--- a/lib/yt/actions/get.rb
+++ b/lib/yt/actions/get.rb
@@ -25,7 +25,7 @@ module Yt
           params[:host] = 'www.googleapis.com'
           params[:auth] = @auth
           params[:exptected_response] = Net::HTTPOK
-          params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key
+          params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key && !@auth
         end
       end
     end

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -119,7 +119,7 @@ module Yt
           params[:auth] = @auth
           params[:path] = path
           params[:exptected_response] = Net::HTTPOK
-          params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key
+          params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key && !@auth
         end
       end
 

--- a/lib/yt/collections/authentications.rb
+++ b/lib/yt/collections/authentications.rb
@@ -23,6 +23,7 @@ module Yt
           params[:auth] = nil
           params[:body] = auth_params
           params[:camelize_body] = false
+          params[:api_key] = nil
         end
       end
 

--- a/lib/yt/collections/user_infos.rb
+++ b/lib/yt/collections/user_infos.rb
@@ -15,6 +15,7 @@ module Yt
         super.tap do |params|
           params[:path] = '/oauth2/v2/userinfo'
           params[:expected_response] = Net::HTTPOK
+          params[:api_key] = nil
         end
       end
 


### PR DESCRIPTION
all `GET` requests
`POST '/oauth2/v2/userinfo'` request
`POST '/o/oauth2/token'` request