### PR TITLE
Limit retries on refresh tokens

### DIFF
--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -196,7 +196,7 @@ module Yt
     # - when the user has reached the quota for requests/second, and waiting
     #   for a couple of seconds might solve the connection issues.
     def run_again?
-      refresh_token_and_retry? ||
+      refresh_token_and_retry? && sleep_and_retry?(3) ||
       server_error? && sleep_and_retry?(3) ||
       exceeded_quota? && sleep_and_retry?(3)
     end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -67,6 +67,16 @@ describe Yt::Request do
         it { expect{request.run}.to fail }
       end
 
+      context 'an error code 401 with a refresh token' do
+        before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return response }
+        let(:auth) { double(refreshed_access_token?: true, access_token: 'whatever') }
+        let(:request) { Yt::Request.new host: 'example.com', auth: auth }
+        let(:response_class) { Net::HTTPUnauthorized }
+
+        it { expect{request.run}.to fail }
+      end
+
+
       context 'any other non-2XX error code' do
         let(:response_class) { Net::HTTPNotFound }
 


### PR DESCRIPTION
Sometimes YouTube gives a response we're not expecting when refreshing
an access token. We shouldn't keep attempting to refresh if this
happens.