### PR TITLE
Remove comment_count metric of a channel, by YouTube change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ After [registering your app](#configuring-your-app), you can run commands like:
 channel = Yt::Channel.new id: 'UCxO1tY8h1AhOz0T4ENwmpow'
 channel.title #=> "Fullscreen"
 channel.public? #=> true
-channel.comment_count #=> 773
 channel.videos.count #=> 12
 ```
 

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -197,10 +197,6 @@ module Yt
       #   @return [Integer] the number of times the channel has been viewed.
       delegate :view_count, to: :statistics_set
 
-      # @!attribute [r] comment_count
-      #   @return [Integer] the number of comments for the channel.
-      delegate :comment_count, to: :statistics_set
-
       # @!attribute [r] video_count
       #   @return [Integer] the number of videos uploaded to the channel.
       delegate :video_count, to: :statistics_set

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -54,13 +54,6 @@ describe Yt::Channel do
     end
   end
 
-  describe '#comment_count' do
-    context 'given a video with comments' do
-      let(:attrs) { {statistics: {"commentCount"=>"33"}} }
-      it { expect(channel.comment_count).to be 33 }
-    end
-  end
-
   describe '#video_count' do
     context 'given a video with videos' do
       let(:attrs) { {statistics: {"videoCount"=>"42"}} }

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -15,7 +15,6 @@ describe Yt::Channel, :device_app, :vcr do
       # expect(channel.published_at).to be_a Time
       expect(channel.privacy_status).to be_a String
       expect(channel.view_count).to be_an Integer
-      expect(channel.comment_count).to be_an Integer
       expect(channel.video_count).to be_an Integer
       expect(channel.subscriber_count).to be_an Integer
       expect(channel.subscriber_count_visible?).to be_in [true, false]


### PR DESCRIPTION
I received an email from no-reply@youtube.com on Aug 12:

<img width="471" alt="Screen Shot 2020-08-17 at 11 13 28 AM" src="https://user-images.githubusercontent.com/6598297/92524246-a0b91180-f1d6-11ea-879f-3dae7a5daa70.png">

I think this is the only place to be removed accordingly as far as Yt gem is concerned. 