### PR TITLE
Only retry refresh tokens once

### DIFF
--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -196,7 +196,7 @@ module Yt
     # - when the user has reached the quota for requests/second, and waiting
     #   for a couple of seconds might solve the connection issues.
     def run_again?
-      refresh_token_and_retry? && sleep_and_retry?(3) ||
+      refresh_token_and_retry? && sleep_and_retry?(1) ||
       server_error? && sleep_and_retry?(3) ||
       exceeded_quota? && sleep_and_retry?(3)
     end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -68,14 +68,13 @@ describe Yt::Request do
       end
 
       context 'an error code 401 with a refresh token' do
-        before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return response }
+        before { expect(Net::HTTP).to receive(:start).twice.and_return response }
         let(:auth) { double(refreshed_access_token?: true, access_token: 'whatever') }
         let(:request) { Yt::Request.new host: 'example.com', auth: auth }
         let(:response_class) { Net::HTTPUnauthorized }
 
         it { expect{request.run}.to fail }
       end
-
 
       context 'any other non-2XX error code' do
         let(:response_class) { Net::HTTPNotFound }


### PR DESCRIPTION
We should only retry exchanging the refresh token once, since if it
fails it's not likely to succeed and there's something else going on.