### PR TITLE
Made for kids support

### DIFF
--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -67,13 +67,19 @@ module Yt
       # @option params [String] :description The video’s description.
       # @option params [Array<String>] :tags The video’s tags.
       # @option params [String] :privacy_status The video’s privacy status.
+      # @option params [Boolean] :self_declared_made_for_kids The video’s made for kids self-declaration.
       # @return [Yt::Models::Video] the newly uploaded video.
       def upload_video(path_or_url, params = {})
         file = open path_or_url, 'rb'
         session = resumable_sessions.insert file.size, upload_body(params)
 
         session.update(body: file) do |data|
-          Yt::Video.new id: data['id'], snippet: data['snippet'], status: data['privacyStatus'], auth: self
+          Yt::Video.new(
+            id: data['id'],
+            snippet: data['snippet'],
+            status: data['status'],
+            auth: self
+          )
         end
       end
 
@@ -217,8 +223,12 @@ module Yt
           snippet[:categoryId] = snippet.delete(:category_id) if snippet[:category_id]
           body[:snippet] = snippet if snippet.any?
 
-          status = params[:privacy_status]
-          body[:status] = {privacyStatus: status} if status
+          privacy_status = params[:privacy_status]
+          self_declared_made_for_kids = params[:self_declared_made_for_kids]
+
+          body[:status] = {}
+          body[:status][:privacyStatus] = privacy_status if privacy_status
+          body[:status][:selfDeclaredMadeForKids] = self_declared_made_for_kids unless self_declared_made_for_kids.nil?
         end
       end
 

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -29,6 +29,25 @@ module Yt
       #   @return [Time] the date and time that the channel was created.
       delegate :published_at, to: :snippet
 
+    ### STATUS ###
+
+      # @!attribute [r] made_for_kids?
+      #   @return [Boolean, nil] This value indicates whether the channel is
+      #     designated as child-directed, and it contains the current "made for
+      #     kids" status of the channel.
+      def made_for_kids?
+        status.made_for_kids
+      end
+
+      # @!attribute [r] self_declared_made_for_kids?
+      #   @return [Boolean, nil] In a channels.update request, this property
+      #     allows the channel owner to designate the channel as
+      #     child-directed. The property value is only returned if the channel
+      #     owner authorized the API request.
+      def self_declared_made_for_kids?
+        status.self_declared_made_for_kids
+      end
+
     ### SUBSCRIPTION ###
 
       has_one :subscription

--- a/lib/yt/models/status.rb
+++ b/lib/yt/models/status.rb
@@ -27,6 +27,8 @@ module Yt
       has_attribute :embeddable
       has_attribute :public_stats_viewable
       has_attribute :publish_at, type: Time
+      has_attribute :made_for_kids
+      has_attribute :self_declared_made_for_kids
     end
   end
 end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -223,6 +223,21 @@ module Yt
         status.embeddable
       end
 
+      #   @return [Boolean, nil] This value indicates whether the video is
+      #     designated as child-directed, and it contains the current "made for
+      #     kids" status of the video.
+      def made_for_kids?
+        status.made_for_kids
+      end
+
+      #   @return [Boolean, nil] In a videos.insert or videos.update request,
+      #     this property allows the channel owner to designate the video as
+      #     being child-directed. In a videos.list request, the property value
+      #     is only returned if the channel owner authorized the API request.
+      def self_declared_made_for_kids?
+        status.self_declared_made_for_kids
+      end
+
     ### CONTENT DETAILS ###
 
       has_one :content_detail
@@ -667,7 +682,7 @@ module Yt
         snippet_keys = [:title, :description, :tags, :category_id]
         snippet = {keys: snippet_keys, sanitize_brackets: true}
         status_keys = [:privacy_status, :embeddable, :license,
-          :public_stats_viewable, :publish_at]
+          :public_stats_viewable, :publish_at, :self_declared_made_for_kids]
         {snippet: snippet, status: {keys: status_keys}}
       end
 

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -28,6 +28,30 @@ describe Yt::Channel do
     end
   end
 
+  describe '#made_for_kids?' do
+    context 'given fetching a status returns madeForKids true' do
+      let(:attrs) { {status: {"madeForKids"=>true}} }
+      it { expect(channel).to be_made_for_kids }
+    end
+
+    context 'given fetching a status returns madeForKids false' do
+      let(:attrs) { {status: {"madeForKids"=>false}} }
+      it { expect(channel).not_to be_made_for_kids }
+    end
+  end
+
+  describe '#self_declared_made_for_kids?' do
+    context 'given fetching a status returns selfDeclaredMadeForKids true' do
+      let(:attrs) { {status: {"selfDeclaredMadeForKids"=>true}} }
+      it { expect(channel).to be_self_declared_made_for_kids }
+    end
+
+    context 'given fetching a status returns selfDeclaredMadeForKids false' do
+      let(:attrs) { {status: {"selfDeclaredMadeForKids"=>false}} }
+      it { expect(channel).not_to be_self_declared_made_for_kids }
+    end
+  end
+
   describe '#thumbnail_url' do
     context 'given a snippet with thumbnails' do
       let(:attrs) { {snippet: {"thumbnails"=>{

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -122,7 +122,6 @@ describe Yt::Video do
     end
   end
 
-
   describe '#deleted?' do
     context 'given fetching a status returns uploadStatus "deleted"' do
       let(:attrs) { {status: {"uploadStatus"=>"deleted"}} }
@@ -487,6 +486,30 @@ describe Yt::Video do
     context 'given a video with a content rating but not ytRating' do
       let(:attrs) { {content_details: {"contentRating"=>{"acbRating": "PG"}}} }
       it { expect(video).not_to be_age_restricted }
+    end
+  end
+
+  describe '#made_for_kids?' do
+    context 'given fetching a status returns madeForKids true' do
+      let(:attrs) { {status: {"madeForKids"=>true}} }
+      it { expect(video).to be_made_for_kids }
+    end
+
+    context 'given fetching a status returns madeForKids false' do
+      let(:attrs) { {status: {"madeForKids"=>false}} }
+      it { expect(video).not_to be_made_for_kids }
+    end
+  end
+
+  describe '#self_declared_made_for_kids?' do
+    context 'given fetching a status returns selfDeclaredMadeForKids true' do
+      let(:attrs) { {status: {"selfDeclaredMadeForKids"=>true}} }
+      it { expect(video).to be_self_declared_made_for_kids }
+    end
+
+    context 'given fetching a status returns selfDeclaredMadeForKids false' do
+      let(:attrs) { {status: {"selfDeclaredMadeForKids"=>false}} }
+      it { expect(video).not_to be_self_declared_made_for_kids }
     end
   end
 

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -108,7 +108,9 @@ describe Yt::Account, :device_app, :vcr do
   end
 
   describe '.upload_video' do
-    let(:video_params) { {title: 'Test Yt upload', privacy_status: 'private', category_id: 17} }
+    let(:video_params) do
+      {title: 'Test Yt upload', privacy_status: 'private', category_id: 17, self_declared_made_for_kids: true}
+    end
     let(:video) { test_account.upload_video path_or_url, video_params }
     after { video.delete }
 


### PR DESCRIPTION
It adds support for the following fields:

- https://developers.google.com/youtube/v3/docs/videos#status.madeForKids
- https://developers.google.com/youtube/v3/docs/videos#status.selfDeclaredMadeForKids
- https://developers.google.com/youtube/v3/docs/channels#status.madeForKids
- https://developers.google.com/youtube/v3/docs/channels#status.selfDeclaredMadeForKids