### PR TITLE
Don't retry on quota errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.33.4 - 2021-01-15
+
+* [REMOVAL] remove retry for quota errors
+
 ## 0.33.3 - 2020-11-17
 
 * [BUGFIX] require the `URL` model when requiring `yt`

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -197,8 +197,7 @@ module Yt
     #   for a couple of seconds might solve the connection issues.
     def run_again?
       refresh_token_and_retry? && sleep_and_retry?(1) ||
-      server_error? && sleep_and_retry?(3) ||
-      exceeded_quota? && sleep_and_retry?(3)
+      server_error? && sleep_and_retry?(3)
     end
 
     # Returns the list of server errors worth retrying the request once.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.33.3'
+  VERSION = '0.33.4'
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -45,19 +45,8 @@ describe Yt::Request do
         let(:response_class) { Net::HTTPForbidden }
         let(:retry_response) { retry_response_class.new nil, nil, nil }
         let(:response_body) { "{\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"youtube.quota\",\n    \"reason\": \"quotaExceeded\",\n    \"message\": \"The request cannot be completed because you have exceeded your \\u003ca href=\\\"/youtube/v3/getting-started#quota\\\"\\u003equota\\u003c/a\\u003e.\"\n   }\n  ],\n  \"code\": 403,\n  \"message\": \"The request cannot be completed because you have exceeded your \\u003ca href=\\\"/youtube/v3/getting-started#quota\\\"\\u003equota\\u003c/a\\u003e.\"\n }\n}\n" }
-        before { allow(retry_response).to receive(:body) }
-        before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return retry_response }
-
         context 'every time' do
-          let(:retry_response_class) { Net::HTTPForbidden }
-
           it { expect{request.run}.to fail }
-        end
-
-        context 'but returns a success code 2XX the second time' do
-          let(:retry_response_class) { Net::HTTPOK }
-
-          it { expect{request.run}.not_to fail }
         end
       end
 


### PR DESCRIPTION
They say that insanity is doing the same thing over and over and
expecting different results...

This patch removes retry behavior on quota issues because:

* this isn't useful when daily quota has been reached
* in the case of 100s quota, you'd need to be attempting requests ~61s
into the quota cool-off in order for the final retry to succeed. That
seems pretty unlikely.

So for all practical purposes, when quota is reached, the library stalls
for the maximum timeout time (39s by my math). This is further
problematic when making requests in environments like Heroku that have
a 30s timeout for web request-response cycles.

Let's do the sane thing and just raise an error when quota is reached.