### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 notifications:
   email: true
+cache: bundler
 matrix:
   include:
   - rvm: 2.6.3


### PR DESCRIPTION
Would be interested to know why Travis caching hasn't been enabled in this repository. Thank you.
