### PR TITLE
Added support for showing processing details to videos

### DIFF
--- a/lib/yt/collections/processing_details.rb
+++ b/lib/yt/collections/processing_details.rb
@@ -1,0 +1,30 @@
+require 'yt/collections/base'
+require 'yt/models/file_detail'
+
+module Yt
+  module Collections
+    # @private
+    class ProcessingDetails < Base
+
+    private
+
+      def attributes_for_new_item(data)
+        {data: data['processingDetails']}
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get the
+      #   file detail of a video.
+      # @see https://developers.google.com/youtube/v3/docs/videos#fileDetails
+      def list_params
+        super.tap do |params|
+          params[:params] = processing_details_params
+          params[:path] = '/youtube/v3/videos'
+        end
+      end
+
+      def processing_details_params
+        {max_results: 50, part: 'processingDetails', id: @parent.id}
+      end
+    end
+  end
+end

--- a/lib/yt/models/processing_detail.rb
+++ b/lib/yt/models/processing_detail.rb
@@ -1,0 +1,20 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # @private
+    # Encapsulates basic information about YouTube's progress in processing the
+    # uploaded video file.
+    # @see https://developers.google.com/youtube/v3/docs/videos#processingDetails
+    class ProcessingDetail < Base
+      attr_reader :data
+
+      def initialize(options = {})
+        @data = options[:data] || {}
+      end
+
+      has_attribute :processing_status
+
+    end
+  end
+end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -299,6 +299,16 @@ module Yt
       delegate :container, to: :file_detail
 
 
+    ### PROCESSING DETAILS ###
+
+      has_one :processing_detail
+
+      # @!attribute [r] container
+      #   @return [String] The video's processing status. This value indicates whether
+      #     YouTube was able to process the video or if the video is still being processed
+      delegate :processing_status, to: :processing_detail
+
+
     ### RATING ###
 
       has_one :rating
@@ -613,6 +623,9 @@ module Yt
         end
         if options[:file_details]
           @file_detail = FileDetail.new data: options[:file_details]
+        end
+        if options[:processing_details]
+          @processing_detail = ProcessingDetail.new data: options[:processing_details]
         end
         if options[:live_streaming_details]
           @live_streaming_detail = LiveStreamingDetail.new data: options[:live_streaming_details]


### PR DESCRIPTION
For a project I'm working on, I need access to see if a video has been processed by YouTube.
YouTube has this in their API but this currently wasn't part of the gem so this pull request adds a very basic version of it and passes through the `processing_status` attribute.

Here are the API docs for the `processingDetails` part - https://developers.google.com/youtube/v3/docs/videos#processingDetails

I'd like to also have access to the `processingProgress` part too but I wasn't too sure how to add this so I'd appreciate some help in adding this too! :smile: 