### PR TITLE
Removed dependency on the deprecated open-uri in Ruby 3

### DIFF
--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 require 'yt/models/base'
 
 module Yt
@@ -70,7 +69,7 @@ module Yt
       # @option params [Boolean] :self_declared_made_for_kids The video’s made for kids self-declaration.
       # @return [Yt::Models::Video] the newly uploaded video.
       def upload_video(path_or_url, params = {})
-        file = open path_or_url, 'rb'
+        file = URI.open(path_or_url)
         session = resumable_sessions.insert file.size, upload_body(params)
 
         session.update(body: file) do |data|

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -54,7 +54,7 @@ module Yt
       # @option params [String] :content_type The type of content being uploaded.
       # @return [Yt::Models::Reference] the newly uploaded reference.
       def upload_reference_file(path_or_url, params = {})
-        file = open path_or_url, 'rb'
+        file = URI.open(path_or_url)
         session = resumable_sessions.insert file.size, params
 
         session.update(body: file) do |data|

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -542,7 +542,7 @@ module Yt
       # @raise [Yt::Errors::RequestError] if path_or_url is not a valid path
       #   or URL.
       def upload_thumbnail(path_or_url)
-        file = open(path_or_url, 'rb') rescue StringIO.new
+        file = URI.open(path_or_url) rescue StringIO.new
         session = resumable_sessions.insert file.size
 
         session.update(body: file) do |data|


### PR DESCRIPTION
Relying on URI.open() instead

https://stackoverflow.com/a/65939036