### PR TITLE
Add access to an account's sub ID in the v3 API

### DIFF
--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -14,6 +14,10 @@ module Yt
       #   @return [String] the (Google+) account’s ID.
       delegate :id, to: :user_info
 
+      # @!attribute [r] sub
+      #   @return [String] the (Google) account’s unique ID.
+      delegate :sub, to: :user_info
+
       # @!attribute [r] email
       #   @return [String] the account’s email address.
       delegate :email, to: :user_info

--- a/lib/yt/models/user_info.rb
+++ b/lib/yt/models/user_info.rb
@@ -11,6 +11,7 @@ module Yt
       end
 
       has_attribute :id, default: ''
+      has_attribute :sub, default: ''
       has_attribute :email, default: ''
       has_attribute :verified_email, default: false, camelize: false
       has_attribute :name, default: ''

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -16,6 +16,18 @@ describe Yt::Video do
     end
   end
 
+  describe '#sub' do
+    context 'given a user info with an ID' do
+      let(:attrs) { {user_info: {"sub"=>"103024385"}} }
+      it { expect(account.sub).to eq '103024385' }
+    end
+
+    context 'given a user info without an ID' do
+      let(:attrs) { {user_info: {}} }
+      it { expect(account.sub).to eq '' }
+    end
+  end
+
   describe '#email' do
     context 'given a user info with an email' do
       let(:attrs) { {user_info: {"email"=>"user@example.com"}} }


### PR DESCRIPTION
The v3 API no longer appears to return an "id" value, but instead a "sub" value that is the account's unique identifier.

See: https://developers.google.com/identity/openid-connect/openid-connect

Should the id method be deleted? @kangkyu what are your thoughts?