### PR TITLE
Fix misspelled key name, exptected_response

### DIFF
--- a/lib/yt/actions/get.rb
+++ b/lib/yt/actions/get.rb
@@ -24,7 +24,7 @@ module Yt
           params[:method] = :get
           params[:host] = 'www.googleapis.com'
           params[:auth] = @auth
-          params[:exptected_response] = Net::HTTPOK
+          params[:expected_response] = Net::HTTPOK
           params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key
         end
       end

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -117,7 +117,7 @@ module Yt
           params[:host] = 'www.googleapis.com'
           params[:auth] = @auth
           params[:path] = path
-          params[:exptected_response] = Net::HTTPOK
+          params[:expected_response] = Net::HTTPOK
           params[:api_key] = Yt.configuration.api_key if Yt.configuration.api_key
         end
       end


### PR DESCRIPTION
Two keys are misspelled in get and list actions. This PR simply corrects them.