### PR TITLE
Fix upload_video "private method 'open' called for an instance of URI::Generic" error

### DIFF
--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -74,7 +74,7 @@ module Yt
       # @option params [Boolean] :self_declared_made_for_kids The video’s made for kids self-declaration.
       # @return [Yt::Models::Video] the newly uploaded video.
       def upload_video(path_or_url, params = {})
-        file = URI.parse(path_or_url).open
+        file = URI.open(path_or_url)
         session = resumable_sessions.insert file.size, upload_body(params)
 
         session.update(body: file) do |data|


### PR DESCRIPTION
Calling `Account#upload_video` on `master` with a file path string (no `file://` URI scheme), I get a `private method 'open' called for an instance of URI::Generic` error that wasn't fixed by #438.

This PR [changes](/nullscreen/yt/blob/16944ffb0876389a07c86a72d3e7a06f1455bba6/lib/yt/models/account.rb#L77)
```
file = URI.parse(path_or_url).open
```
to
```
file = URI.open(path_or_url)
````
[`open`](/ruby/ruby/blob/5b5b5b3af555a0349c3d7e4e2a50f36ecd848560/lib/open-uri.rb#L23) automatically parses first when its argument is a string-with-scheme, and defers to `Kernel#open` for paths.

I'm testing on Ruby 3.4.5. But looking at [the history of `open-uri.rb`](/ruby/ruby/commits/master/lib/open-uri.rb), this call to `open` should work on even ancient Ruby versions.