### PR TITLE
Fix upload_thumbnail from path

### DIFF
--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -1,3 +1,4 @@
+require 'open-uri'
 require 'yt/models/resource'
 
 module Yt
@@ -549,7 +550,7 @@ module Yt
       # @raise [Yt::Errors::RequestError] if path_or_url is not a valid path
       #   or URL.
       def upload_thumbnail(path_or_url)
-        file = URI.parse(path_or_url).open rescue StringIO.new
+        file = URI.open(path_or_url)
         session = resumable_sessions.insert file.size
 
         session.update(body: file) do |data|


### PR DESCRIPTION
Like #448 fixed `upload_video` with a path URI, this does the same with `upload_thumbnail`.