### PR TITLE
Handle missing duration for video premieres

### DIFF
--- a/lib/yt/models/content_detail.rb
+++ b/lib/yt/models/content_detail.rb
@@ -14,6 +14,8 @@ module Yt
       end
 
       # @return [Integer] the duration of the video (in seconds).
+      #   Returns 0 for ongoing live broadcasts and premieres, since the
+      #   YouTube API does not report a duration until they have ended.
       has_attribute :duration, default: 0 do |value|
         to_seconds value
       end
@@ -59,6 +61,8 @@ module Yt
       # such as minutes is not part of the standard either; in this context,
       # it will be interpreted as "0 minutes and 2 seconds".
       def to_seconds(iso8601_duration)
+        return iso8601_duration.to_i unless iso8601_duration.is_a? String
+
         match = iso8601_duration.match %r{^P(?:|(?<weeks>\d*?)W)(?:|(?<days>\d*?)D)(?:|T(?:|(?<hours>\d*?)H)(?:|(?<min>\d*?)M)(?:|(?<sec>\d*?)S))$}
         weeks = (match[:weeks] || '0').to_i
         days = (match[:days] || '0').to_i

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -245,10 +245,14 @@ module Yt
 
       # @!attribute [r] duration
       #   @return [Integer] the duration of the video (in seconds).
+      #     Returns 0 for ongoing live broadcasts and premieres, since the
+      #     YouTube API does not report a duration until they have ended.
       delegate :duration, to: :content_detail
 
       # @!attribute [r] duration
       #   @return [String] the length of the video as an ISO 8601 time, HH:MM:SS.
+      #     Returns "00:00:00" for ongoing live broadcasts and premieres, since
+      #     the YouTube API does not report a duration until they have ended.
       delegate :length, to: :content_detail
 
       # @return [Boolean] whether the video is available in 3D.

--- a/spec/models/content_detail_spec.rb
+++ b/spec/models/content_detail_spec.rb
@@ -41,12 +41,22 @@ describe Yt::ContentDetail do
       let(:data) { {"duration"=>"PT51S"} }
       it { expect(content_detail.duration).to eq 51 }
     end
+
+    context 'given a content_detail without a duration (e.g. an upcoming premiere)' do
+      let(:data) { {} }
+      it { expect(content_detail.duration).to eq 0 }
+    end
   end
 
   describe '#length' do
     context 'returns the duration in HH:MM:SS' do
       let(:data) { {"duration"=>"PT1H18M52S"} }
       it { expect(content_detail.length).to eq '01:18:52' }
+    end
+
+    context 'given a content_detail without a duration (e.g. an upcoming premiere)' do
+      let(:data) { {} }
+      it { expect(content_detail.length).to eq '00:00:00' }
     end
   end
 end


### PR DESCRIPTION
The YouTube API omits `contentDetails.duration` while a video is an ongoing premiere. The default value `0` was then passed to `to_seconds`, which expects an ISO 8601 string, raising  `undefined method 'match' for an instance of Integer`:

```
duration error: NoMethodError: undefined method 'match' for an instance of Integer
  /Users/marcoroth/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/yt-0.34.1/lib/yt/models/content_detail.rb:62:in 'Yt::Models::ContentDetail#to_seconds'
  /Users/marcoroth/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/yt-0.34.1/lib/yt/models/content_detail.rb:18:in 'block in <class:ContentDetail>'
```

This pull request fixes this so that `Video#duration` now returns `0` and `Video#length` `"00:00:00"` in that case.