### PR TITLE
Update docs URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available resources
 Yt::Account
 -----------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/accounts.html) for the list of methods available for `Yt::Account`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/accounts.html) for the list of methods available for `Yt::Account`.
 
 
 Yt::ContentOwner
@@ -109,22 +109,22 @@ content_owner.assets.first.custom_id #=> "MoKNJFOIRroc"
 Yt::Channel
 -----------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/channels.html) for the list of methods available for `Yt::Channel`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/channels.html) for the list of methods available for `Yt::Channel`.
 
 Yt::Video
 ---------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/videos.html) for the list of methods available for `Yt::Video`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/videos.html) for the list of methods available for `Yt::Video`.
 
 Yt::Playlist
 ------------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/playlists.html) for the list of methods available for `Yt::Playlist`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/playlists.html) for the list of methods available for `Yt::Playlist`.
 
 Yt::PlaylistItem
 ----------------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/playlist_items.html) for the list of methods available for `Yt::PlaylistItem`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/playlist_items.html) for the list of methods available for `Yt::PlaylistItem`.
 
 Yt::CommentThread
 ----------------
@@ -217,7 +217,7 @@ videos.where(id: 'jNQXAC9IVRw,invalid').map(&:title) #=> ["Fullscreen Creator Pl
 Yt::Annotation
 --------------
 
-Check [nullscreen.github.io/yt](http://nullscreen.github.io/yt/annotations.html) for the list of methods available for `Yt::Annotation`.
+Check [claudiob.github.io/yt](https://claudiob.github.io/yt/annotations.html) for the list of methods available for `Yt::Annotation`.
 
 
 Yt::MatchPolicy


### PR DESCRIPTION
Looks like the docs URL changed and the old URL is not reachable anymore, this PR updates the docs URL in the README to match the new URL listed in the repository.